### PR TITLE
Fix reader failing on comment as last element in list

### DIFF
--- a/src/csharp/ParserTests/ReaderTests.cs
+++ b/src/csharp/ParserTests/ReaderTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Semgus.Parser.Reader;
+
+using Xunit;
+
+namespace ParserTests
+{
+    public class ReaderTests
+    {
+        /// <summary>
+        /// https://github.com/SemGuS-git/Semgus-Parser/issues/23
+        /// </summary>
+        [Fact]
+        public void HandlesCommentAtEndOfList()
+        {
+            SemgusReader reader = new(@"
+(list 1 2 3
+  ; This is a comment
+)
+");
+            SemgusToken tok = reader.Read();
+            var cons = Assert.IsType<ConsToken>(tok);
+
+            Assert.True(cons.TryPop(out SymbolToken symb, out cons, out _, out _));
+            Assert.Equal("list", symb.Name);
+
+            Assert.True(cons.TryPop(out NumeralToken num, out cons, out _, out _));
+            Assert.Equal(1, num.Value);
+
+            Assert.True(cons.TryPop(out num, out cons, out _, out _));
+            Assert.Equal(2, num.Value);
+
+            Assert.True(cons.TryPop(out num, out cons, out _, out _));
+            Assert.Equal(3, num.Value);
+
+            Assert.Null(cons);
+        }
+
+        [Fact]
+        public void ThrowsOnExtraRightParenthesis()
+        {
+            SemgusReader reader = new(@"(1)) (2)");
+            reader.Read(); // (1);
+            Assert.Throws<Exception>(() => reader.Read());
+        }
+
+        [Fact]
+        public void ThrowsOnUnmatchedLeftParenthesis()
+        {
+            SemgusReader reader = new(@"((1)");
+            Assert.Throws<Exception>(() => reader.Read());
+        }
+    }
+}

--- a/src/csharp/S-Expressions/Reader/SexprReader.cs
+++ b/src/csharp/S-Expressions/Reader/SexprReader.cs
@@ -440,7 +440,15 @@ namespace Semgus.Sexpr.Reader
                 }
                 else
                 {
-                    list.Add(Read());
+                    var sexpr = ReadImpl();
+                    if (sexpr!.Equals(NothingSentinel) || sexpr!.Equals(EndOfFileSentinel))
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        list.Add(sexpr);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #23. The `ReadDelimitedList` method is updated to call `ReadImpl` and handle the sentinels as appropriate.

Also added a unit test for this.