### PR TITLE
Improve Error Position Tracking

### DIFF
--- a/ParserExample/ExampleSemgusProblemHandler.cs
+++ b/ParserExample/ExampleSemgusProblemHandler.cs
@@ -17,7 +17,7 @@ namespace Semgus.Parser.Example
             Console.WriteLine("declare-term-types: ");
             foreach (var tt in termTypes)
             {
-                Console.Write("  " + tt.Name.Symbol + " -->");
+                Console.Write("  " + tt.Name + " -->");
                 bool firstConstructor = true;
                 foreach (var cons in tt.Constructors)
                 {

--- a/ParserLibrary/Commands/ConstraintCommand.cs
+++ b/ParserLibrary/Commands/ConstraintCommand.cs
@@ -5,6 +5,7 @@ using System.IO;
 using Semgus.Parser.Reader;
 
 using Semgus.Model.Smt.Terms;
+using Microsoft.Extensions.Logging;
 
 namespace Semgus.Parser.Commands
 {
@@ -12,24 +13,28 @@ namespace Semgus.Parser.Commands
     /// Command for adding a new constraint into the SemGuS problem
     /// Syntax: (constraint [predicate])
     /// </summary>
-    public class ConstraintCommand
+    internal class ConstraintCommand
     {
         private readonly ISemgusProblemHandler _problemHandler;
         private readonly ISmtContextProvider _smtProvider;
         private readonly ISemgusContextProvider _semgusProvider;
+        private readonly ISourceMap _sourceMap;
+        private readonly ILogger<ConstraintCommand> _logger;
 
-        public ConstraintCommand(ISemgusProblemHandler handler, ISmtContextProvider smtProvider, ISemgusContextProvider semgusProvider)
+        public ConstraintCommand(ISemgusProblemHandler handler, ISmtContextProvider smtProvider, ISemgusContextProvider semgusProvider, ISourceMap sourceMap, ILogger<ConstraintCommand> logger)
         {
             _problemHandler = handler;
             _smtProvider = smtProvider;
             _semgusProvider = semgusProvider;
+            _sourceMap = sourceMap;
+            _logger = logger;
         }
 
         [Command("constraint")]
         public void Constraint(SmtTerm predicate)
         {
             // Only Boolean constraints are valid
-            var boolSort = _smtProvider.Context.GetSortDeclaration(new("Bool"));
+            var boolSort = _smtProvider.Context.GetSortOrDie(new("Bool"), _sourceMap, _logger);
             if (predicate.Sort == boolSort)
             {
                 _semgusProvider.Context.AddConstraint(predicate);

--- a/ParserLibrary/Commands/DeclareTermTypeCommand.cs
+++ b/ParserLibrary/Commands/DeclareTermTypeCommand.cs
@@ -5,9 +5,13 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Logging;
+
 using Semgus.Model;
 using Semgus.Model.Smt;
 using Semgus.Parser.Reader;
+
+#nullable enable
 
 namespace Semgus.Parser.Commands
 {
@@ -15,25 +19,31 @@ namespace Semgus.Parser.Commands
     /// Command for declaring a new term type.
     /// Syntax: (declare-term-type [typename])
     /// </summary>
-    public class DeclareTermTypeCommand
+    internal class DeclareTermTypeCommand
     {
         private readonly ISemgusProblemHandler _handler;
         private readonly ISmtContextProvider _context;
         private readonly ISmtConverter _converter;
+        private readonly ISourceMap _sourceMap;
+        private readonly ILogger<DeclareTermTypeCommand> _logger;
 
-        public DeclareTermTypeCommand(ISemgusProblemHandler handler, ISmtContextProvider context, ISmtConverter converter)
+        public DeclareTermTypeCommand(ISemgusProblemHandler handler, ISmtContextProvider context, ISmtConverter converter, ISourceMap sourceMap, ILogger<DeclareTermTypeCommand> logger)
         {
             _handler = handler;
             _context = context;
             _converter = converter;
+            _sourceMap = sourceMap;
+            _logger = logger;
         }
 
         [Command("declare-term-types")]
         public void DeclareTermType(IList<SortDecl> sortDecls, IList<IList<ConstructorDecl>> constructors)
         {
+            using var loggerScope = _logger.BeginScope("While parsing `declare-term-types` command:");
+
             if (sortDecls.Count != constructors.Count)
             {
-                throw new InvalidOperationException("Term names and constructor lists must be matched.");
+                throw _logger.LogParseErrorAndThrow("Term names and constructor lists must be matched.", _sourceMap[sortDecls]);
             }
 
             List<SemgusTermType> termTypes = new();
@@ -41,7 +51,7 @@ namespace Semgus.Parser.Commands
             {
                 if (decl.Arity != 0)
                 {
-                    throw new InvalidOperationException("Only arity 0 term types allowed.");
+                    throw _logger.LogParseErrorAndThrow("Only arity 0 term types allowed.", _sourceMap[decl]);
                 }
                 SemgusTermType tt = new(decl.Identifier);
                 _context.Context.AddSortDeclaration(tt);
@@ -50,17 +60,21 @@ namespace Semgus.Parser.Commands
 
             for (int ix = 0; ix < termTypes.Count; ++ix)
             {
+                using var loggerTermTypeScope = _logger.BeginScope($"for term type '{termTypes[ix].Name}':");
+
                 foreach (var constructor in constructors[ix])
                 {
+                    using var loggerConstructorScope = _logger.BeginScope($"in constructor '{constructor.Constructor}':");
+
                     List<SmtSort> children = new();
                     foreach (var child in constructor.Children)
                     {
-                        if (_converter.TryConvert(child.Sort, out SmtSort? sort)) {
+                        if (_context.Context.TryGetSortDeclaration(child.Sort, out SmtSort? sort)) {
                             children.Add(sort);
                         }
                         else
                         {
-                            throw new InvalidOperationException("Sort not declared: " + child.Sort);
+                            throw _logger.LogParseErrorAndThrow("Sort not declared: " + child.Sort, _sourceMap[child.Sort]);
                         }
                     }
                     termTypes[ix].AddConstructor(new(constructor.Constructor, children.ToArray()));
@@ -70,7 +84,7 @@ namespace Semgus.Parser.Commands
             _handler.OnTermTypes(termTypes);
         }
 
-        public record SortDecl(SmtIdentifier Identifier, int Arity) { }
-        public record ConstructorDecl(SmtIdentifier Constructor, [Rest] IList<(SmtIdentifier Selector, SemgusToken Sort)> Children) { }
+        public record SortDecl(SmtSortIdentifier Identifier, int Arity) { }
+        public record ConstructorDecl(SmtIdentifier Constructor, [Rest] IList<(SmtIdentifier Selector, SmtSortIdentifier Sort)> Children) { }
     }
 }

--- a/ParserLibrary/Commands/SynthFunCommand.cs
+++ b/ParserLibrary/Commands/SynthFunCommand.cs
@@ -109,8 +109,9 @@ namespace Semgus.Parser.Commands
             using var logScope = _logger.BeginScope("in grammar block:");
 
             List<SemgusGrammar.NonTerminal> nonTerminals = new();
-            foreach (var (id, sort) in grammarForm.ntDecls)
+            foreach (var (id, sortId) in grammarForm.ntDecls)
             {
+                var sort = _smtContext.Context.GetSortOrDie(sortId, _sourceMap, _logger);
                 if (sort is not SemgusTermType stt)
                 {
                     throw _logger.LogParseErrorAndThrow($"Not a term type in synth-fun non-terminal decl: ({id} {sort.Name})", _sourceMap[sort]);
@@ -119,8 +120,9 @@ namespace Semgus.Parser.Commands
             }
 
             List<SemgusGrammar.Production> productions = new();
-            foreach (var (id, sort, terms) in grammarForm.Productions)
+            foreach (var (id, sortId, terms) in grammarForm.Productions)
             {
+                var sort = _smtContext.Context.GetSortOrDie(sortId, _sourceMap, _logger);
                 if (sort is not SemgusTermType stt)
                 {
                     throw _logger.LogParseErrorAndThrow($"Not a term type in synth-fun production: ({id} {sort.Name} ...)", _sourceMap[sort]);
@@ -211,6 +213,6 @@ namespace Semgus.Parser.Commands
             return new SemgusGrammar(nonTerminals, productions);
         }
 
-        public record GrammarForm(IList<(SmtIdentifier Name, SmtSort Sort)> ntDecls, IList<(SmtIdentifier Name, SmtSort Sort, IList<SemgusToken> Productions)> Productions);
+        public record GrammarForm(IList<(SmtIdentifier Name, SmtSortIdentifier Sort)> ntDecls, IList<(SmtIdentifier Name, SmtSortIdentifier Sort, IList<SemgusToken> Productions)> Productions);
     }
 }

--- a/ParserLibrary/ErrorHandlingExtensions.cs
+++ b/ParserLibrary/ErrorHandlingExtensions.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Extensions.Logging;
+
+using Semgus.Model.Smt;
+using Semgus.Parser.Reader;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Semgus.Parser
+{
+    internal static class ErrorHandlingExtensions
+    {
+        /// <summary>
+        /// Attempts to resolve a sort with the given name, or throws a parse exception if not able
+        /// </summary>
+        /// <param name="ctx">This SmtContext</param>
+        /// <param name="id">The sort identifier to resolve</param>
+        /// <param name="sourceMap">Source map for error message generation</param>
+        /// <param name="logger">Logger to log with</param>
+        /// <returns>The resolved sort</returns>
+        /// <exception>FatalParseException when unable to resolve sort</exception>
+        [return: NotNullIfNotNull("id")]
+        public static SmtSort? GetSortOrDie<T>(this SmtContext ctx, SmtSortIdentifier? id, ISourceMap sourceMap, ILogger<T> logger)
+        {
+            if (id is null)
+            {
+                return null;
+            }
+
+            if (!ctx.TryGetSortDeclaration(id, out SmtSort? sort))
+            {
+                throw logger.LogParseErrorAndThrow($"Undeclared sort: {id}", sourceMap[id]);
+            }
+            else
+            {
+                return sort;
+            }
+        }
+    }
+}

--- a/ParserLibrary/Reader/Converters/AnnotationConverter.cs
+++ b/ParserLibrary/Reader/Converters/AnnotationConverter.cs
@@ -86,7 +86,5 @@ namespace Semgus.Parser.Reader.Converters
             to = attributes;
             return true;
         }
-
-        private record ParameterizedSortForm(SmtIdentifier Identifier, [Rest] IList<SmtSort> Parameters) { }
     }
 }

--- a/ParserLibrary/Reader/Converters/AttributeValueConverter.cs
+++ b/ParserLibrary/Reader/Converters/AttributeValueConverter.cs
@@ -60,7 +60,5 @@ namespace Semgus.Parser.Reader.Converters
             to = default;
             return false;
         }
-
-        private record ParameterizedSortForm(SmtIdentifier Identifier, [Rest] IList<SmtSort> Parameters) { }
     }
 }

--- a/ParserLibrary/Reader/Converters/SmtConverter.cs
+++ b/ParserLibrary/Reader/Converters/SmtConverter.cs
@@ -17,12 +17,17 @@ namespace Semgus.Parser.Reader.Converters
     /// <summary>
     /// Interface for converting between S-expression tokens and SMT objects
     /// </summary>
-    public class SmtConverter : ISmtConverter
+    internal class SmtConverter : ISmtConverter
     {
         /// <summary>
         /// Service provider that converters will be taken from
         /// </summary>
         private readonly IServiceProvider _provider;
+
+        /// <summary>
+        /// Map for recording where converted objects come from
+        /// </summary>
+        private readonly ISourceMap _sourceMap;
 
         /// <summary>
         /// Cached list of converters
@@ -55,9 +60,10 @@ namespace Semgus.Parser.Reader.Converters
         /// Constructs a new SmtConverter, where converters will be pulled from the given service provider
         /// </summary>
         /// <param name="provider">Service provider in which to look for converters</param>
-        public SmtConverter(IServiceProvider provider)
+        public SmtConverter(IServiceProvider provider, ISourceMap sourceMap)
         {
             _provider = provider;
+            _sourceMap = sourceMap;
         }
 
         /// <summary>
@@ -75,6 +81,10 @@ namespace Semgus.Parser.Reader.Converters
             {
                 if (converter.CanConvert(tFrom, tTo) && converter.TryConvert(tFrom, tTo, from, out to))
                 {
+                    if (tFrom.IsAssignableTo(typeof(SemgusToken)))
+                    {
+                        _sourceMap[to] = ((SemgusToken)from).Position;
+                    }
                     return true;
                 }
             }

--- a/ParserLibrary/Reader/Converters/SortConverter.cs
+++ b/ParserLibrary/Reader/Converters/SortConverter.cs
@@ -14,17 +14,19 @@ namespace Semgus.Parser.Reader.Converters
     internal class SortConverter : AbstractConverter
     {
         private readonly ISmtConverter _converter;
-        private readonly ISmtContextProvider _context;
 
-        public SortConverter(ISmtConverter converter, ISmtContextProvider context)
+        public SortConverter(ISmtConverter converter)
         {
             _converter = converter;
-            _context = context;
         }
 
         public override bool CanConvert(Type from, Type to)
         {
-            return to == typeof(SmtSort); // Lot of options for this one... && from.IsAssignableFrom(typeof(SymbolToken));
+            if (to == typeof(SmtSort))
+            {
+                throw new InvalidOperationException("SmtSort is not a valid conversion target.");
+            }
+            return to == typeof(SmtSortIdentifier); // Lot of options for this one... && from.IsAssignableFrom(typeof(SymbolToken));
         }
 
         public override bool TryConvertImpl(Type tFrom, Type tTo, object from, [NotNullWhen(true)] out object? to)
@@ -32,24 +34,21 @@ namespace Semgus.Parser.Reader.Converters
             // Sort type 1: just an identifier
             if (_converter.TryConvert(from, out SmtIdentifier? id))
             {
-                to = _context.Context.GetSortDeclaration(id);
+                to = new SmtSortIdentifier(id);
                 return true;
             }
 
             // Sort type 2: identifier application (parameterized sorts)
             if (_converter.TryConvert(from, out ParameterizedSortForm? sortform))
             {
-                var parameterized = _context.Context.GetSortDeclaration(sortform.Identifier);
-                to = _context.Context.ResolveParameterizedSort(parameterized, sortform.Parameters);
+                to = new SmtSortIdentifier(sortform.Identifier, sortform.Parameters.ToArray());
                 return true;
             }
-
-            Console.WriteLine("Unable to resolve sort: " + from.ToString());
 
             to = default;
             return false;
         }
 
-        private record ParameterizedSortForm(SmtIdentifier Identifier, [Rest] IList<SmtSort> Parameters) { }
+        private record ParameterizedSortForm(SmtIdentifier Identifier, [Rest] IList<SmtSortIdentifier> Parameters) { }
     }
 }

--- a/ParserLibrary/Reader/Converters/TermConverter.cs
+++ b/ParserLibrary/Reader/Converters/TermConverter.cs
@@ -438,7 +438,7 @@ namespace Semgus.Parser.Reader.Converters
         }
 
         [return: NotNullIfNotNull("id")]
-        private SmtSort? GetSortOrDie(SmtSortIdentifier id) => _contextProvider.Context.GetSortOrDie(id, _sourceMap, _logger);
+        private SmtSort? GetSortOrDie(SmtSortIdentifier? id) => _contextProvider.Context.GetSortOrDie(id, _sourceMap, _logger);
 
         // Note: child terms for binders are SemgusTokens, since we need to update the scope before parsing them.
         private record AnnotationForm([Exactly("!")] SmtIdentifier _, SmtTerm Child, [Rest] IList<SemgusToken> Attributes);

--- a/ParserLibrary/Reader/Converters/TermConverter.cs
+++ b/ParserLibrary/Reader/Converters/TermConverter.cs
@@ -21,14 +21,16 @@ namespace Semgus.Parser.Reader.Converters
         private readonly ISmtConverter _converter;
         private readonly ISmtScopeProvider _scopeProvider;
         private readonly ISmtContextProvider _contextProvider;
+        private readonly ISourceMap _sourceMap;
         private readonly ILogger<TermConverter> _logger;
         
-        public TermConverter(DestructuringHelper helper, ISmtConverter converter, ISmtScopeProvider scopeProvider, ISmtContextProvider contextProvider, ILogger<TermConverter> logger)
+        public TermConverter(DestructuringHelper helper, ISmtConverter converter, ISmtScopeProvider scopeProvider, ISmtContextProvider contextProvider, ISourceMap sourceMap, ILogger<TermConverter> logger)
         {
             _destructuringHelper = helper;
             _converter = converter;
             _scopeProvider = scopeProvider;
             _contextProvider = contextProvider;
+            _sourceMap = sourceMap;
             _logger = logger;
         }
 
@@ -66,7 +68,7 @@ namespace Semgus.Parser.Reader.Converters
                 }
                 else if (_contextProvider.Context.TryGetFunctionDeclaration(qid.Id, out var defn))
                 {
-                    if (defn.TryResolveRank(out var rank, qid.Sort /* No arguments */))
+                    if (defn.TryResolveRank(out var rank, GetSortOrDie(qid.Sort) /* No arguments */))
                     {
                         to = new SmtFunctionApplication(defn, rank, new List<SmtTerm>());
                     }
@@ -141,7 +143,7 @@ namespace Semgus.Parser.Reader.Converters
                                     using var scopeCx = _scopeProvider.CreateNewScope();
                                     foreach (var (id, sort) in ef.Bindings)
                                     {
-                                        scopeCx.Scope.AddVariableBinding(id, sort, SmtVariableBindingType.Existential);
+                                        scopeCx.Scope.AddVariableBinding(id, GetSortOrDie(sort), SmtVariableBindingType.Existential);
                                     }
                                     if (_converter.TryConvert(ef.Child, out SmtTerm? child))
                                     {
@@ -161,7 +163,7 @@ namespace Semgus.Parser.Reader.Converters
                                     using var scopeCx = _scopeProvider.CreateNewScope();
                                     foreach (var (id, sort) in ff.Bindings)
                                     {
-                                        scopeCx.Scope.AddVariableBinding(id, sort, SmtVariableBindingType.Universal);
+                                        scopeCx.Scope.AddVariableBinding(id, GetSortOrDie(sort), SmtVariableBindingType.Universal);
                                     }
                                     if (_converter.TryConvert(ff.Child, out SmtTerm? child))
                                     {
@@ -283,7 +285,7 @@ namespace Semgus.Parser.Reader.Converters
                                         else
                                         {
                                             _contextProvider.Context.TryGetFunctionDeclaration(new("or"), out SmtFunction? orf);
-                                            var boolsort = _contextProvider.Context.GetSortDeclaration(new("Bool"));
+                                            var boolsort = GetSortOrDie(new("Bool"));
 
                                             // Make sure all terms are of type bool
                                             if (convTerms.Any(t => t.Sort != boolsort))
@@ -366,7 +368,7 @@ namespace Semgus.Parser.Reader.Converters
                                 return true;
                             }
 
-                            if (defn.TryResolveRank(out var rank, af.Id.Sort, argSorts))
+                            if (defn.TryResolveRank(out var rank, GetSortOrDie(af.Id.Sort), argSorts))
                             {
                                 to = new SmtFunctionApplication(defn, rank, args);
                             }
@@ -435,14 +437,17 @@ namespace Semgus.Parser.Reader.Converters
             }
         }
 
+        [return: NotNullIfNotNull("id")]
+        private SmtSort? GetSortOrDie(SmtSortIdentifier id) => _contextProvider.Context.GetSortOrDie(id, _sourceMap, _logger);
+
         // Note: child terms for binders are SemgusTokens, since we need to update the scope before parsing them.
         private record AnnotationForm([Exactly("!")] SmtIdentifier _, SmtTerm Child, [Rest] IList<SemgusToken> Attributes);
         private record LetForm([Exactly("let")] SmtIdentifier _, IList<(SmtIdentifier, SemgusToken)> Bindings, SemgusToken Child);
-        private record ForallForm([Exactly("forall")] SmtIdentifier _, IList<(SmtIdentifier, SmtSort)> Bindings, SemgusToken Child);
-        private record ExistsForm([Exactly("exists")] SmtIdentifier _, IList<(SmtIdentifier, SmtSort)> Bindings, SemgusToken Child);
+        private record ForallForm([Exactly("forall")] SmtIdentifier _, IList<(SmtIdentifier, SmtSortIdentifier)> Bindings, SemgusToken Child);
+        private record ExistsForm([Exactly("exists")] SmtIdentifier _, IList<(SmtIdentifier, SmtSortIdentifier)> Bindings, SemgusToken Child);
         private record MatchPattern(SemgusToken Pattern, [Rest] IList<SemgusToken> Terms);
         private record MatchForm([Exactly("match")] SmtIdentifier _, SmtTerm TermToMatch, IList<MatchPattern> Patterns);
-        private record QualifiedIdentifier([Exactly("as")] SymbolToken? _, SmtIdentifier Id, SmtSort? Sort)
+        private record QualifiedIdentifier([Exactly("as")] SymbolToken? _, SmtIdentifier Id, SmtSortIdentifier? Sort)
         {
             public QualifiedIdentifier(SmtIdentifier Id) : this(null, Id, null) { }
         }

--- a/ParserLibrary/Reader/ErrorSort.cs
+++ b/ParserLibrary/Reader/ErrorSort.cs
@@ -14,6 +14,6 @@ namespace Semgus.Parser.Reader
     internal class ErrorSort : SmtSort
     {
         public static ErrorSort Instance { get; } = new ErrorSort();
-        private ErrorSort() : base(new SmtIdentifier("@error")) { }
+        private ErrorSort() : base(new SmtSortIdentifier("@error")) { }
     }
 }

--- a/ParserLibrary/Reader/ISourceContextProvider.cs
+++ b/ParserLibrary/Reader/ISourceContextProvider.cs
@@ -1,0 +1,25 @@
+﻿using Semgus.Sexpr.Reader;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Semgus.Parser.Reader
+{
+    /// <summary>
+    /// Provides context information (i.e., text) for a given error position
+    /// </summary>
+    internal interface ISourceContextProvider
+    {
+        /// <summary>
+        /// Tries to get the full line of where an error occurred
+        /// </summary>
+        /// <param name="position">Position to look up</param>
+        /// <returns>Source line</returns>
+        bool TryGetSourceLine(SexprPosition? position, out string? line);
+    }
+}

--- a/ParserLibrary/Reader/ISourceMap.cs
+++ b/ParserLibrary/Reader/ISourceMap.cs
@@ -1,0 +1,25 @@
+﻿using Semgus.Sexpr.Reader;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Semgus.Parser.Reader
+{
+    /// <summary>
+    /// Stores a mapping between objects and their position in an input stream
+    /// </summary>
+    internal interface ISourceMap
+    {
+        /// <summary>
+        /// The position for a given object
+        /// </summary>
+        /// <param name="key">Object for source mapping</param>
+        /// <returns>Position of the object</returns>
+        SexprPosition this[object key] { get; set; }
+    }
+}

--- a/ParserLibrary/Reader/ReaderLogger.cs
+++ b/ParserLibrary/Reader/ReaderLogger.cs
@@ -14,49 +14,98 @@ using Semgus.Sexpr.Reader;
 
 namespace Semgus.Parser.Reader
 {
+    /// <summary>
+    /// An ILogger implementation for use in reading SemGuS files
+    /// </summary>
     internal class ReaderLogger : ILogger
     {
+        /// <summary>
+        /// Writer that is logged to
+        /// </summary>
         private readonly TextWriter _writer;
+
+        /// <summary>
+        /// Current stack of scopes, providing context information about where a message is logged
+        /// </summary>
         private readonly Stack<string> _scopeStack;
 
-        public ReaderLogger(Stream stream) : this(new StreamWriter(stream))
+        /// <summary>
+        /// Provider for additional context information about errors
+        /// </summary>
+        private readonly ISourceContextProvider _sourceContextProvider;
+
+        /// <summary>
+        /// Constructs a new ReaderLogger with the given context provider and stream to log to
+        /// </summary>
+        /// <param name="scp">Source context provider</param>
+        /// <param name="stream">Stream to log to</param>
+        public ReaderLogger(ISourceContextProvider scp, Stream stream) : this(scp, new StreamWriter(stream))
         {
         }
 
-        public ReaderLogger(TextWriter tw)
+        /// <summary>
+        /// Constructs a new ReaderLogger with the given context provider and text writer to log to
+        /// </summary>
+        /// <param name="scp">Source context provider</param>
+        /// <param name="tw">Text writer to log to</param>
+        public ReaderLogger(ISourceContextProvider scp, TextWriter tw)
         {
+            _sourceContextProvider = scp;
             _writer = tw;
             _scopeStack = new Stack<string>();
         }
 
+        /// <summary>
+        /// Helper class for automatically removing scopes when disposed
+        /// </summary>
         private class ScopeStackPopper : IDisposable
         {
+            /// <summary>
+            /// The owning logger
+            /// </summary>
             private readonly ReaderLogger _parent;
+
+            /// <summary>
+            /// Creates a new ScopeStackPopper for the given logger
+            /// </summary>
+            /// <param name="parent">The owning logger</param>
             public ScopeStackPopper(ReaderLogger parent)
             {
                 _parent = parent;
             }
 
+            /// <summary>
+            /// Pops the most recent scope off of the parent logger
+            /// </summary>
             public void Dispose()
             {
                 _parent._scopeStack.Pop();
             }
         }
 
+        /// <summary>
+        /// Starts a new scope, providing context to future messages. The string representation of state is printed
+        /// </summary>
+        /// <typeparam name="TState">Arbitrary state type</typeparam>
+        /// <param name="state">Scope state. Turned into a string and logged</param>
+        /// <returns>Disposable that should be disposed of when the scope should be popped</returns>
         public IDisposable BeginScope<TState>(TState state)
         {
             _scopeStack.Push(state?.ToString() ?? "");
             return new ScopeStackPopper(this);
         }
 
+        /// <inheritdoc />
         public bool IsEnabled(LogLevel logLevel)
         {
             return true;
         }
 
+        /// <inheritdoc />
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
-            if (state is ReaderLoggerState rls)
+            var rls = state as ReaderLoggerState;
+            if (rls is not null)
             {
                 _writer.Write($"{rls.Position?.ToString() ?? "0:0:0"}: ");
             }
@@ -67,8 +116,22 @@ namespace Semgus.Parser.Reader
             }
             _writer.Write(formatter(state, exception));
             _writer.WriteLine();
+
+            if (rls is not null &&
+                rls.Position is not null &&
+                _sourceContextProvider.TryGetSourceLine(rls.Position, out var ctxLine))
+            {
+                _writer.WriteLine("Error reported here:");
+                _writer.WriteLine(ctxLine);
+                _writer.WriteLine(new string('-', rls.Position.Column - 1) + "^");
+            }
         }
 
+        /// <summary>
+        /// Converts a log level into a prefix to log with
+        /// </summary>
+        /// <param name="ll">The log level</param>
+        /// <returns>String prefix for logging</returns>
         private static string GetPrefix(LogLevel ll)
         {
             switch (ll)
@@ -84,37 +147,74 @@ namespace Semgus.Parser.Reader
         }
     }
 
+    /// <summary>
+    /// State object for special logging with position and context information
+    /// </summary>
+    /// <param name="Message">The message to log</param>
+    /// <param name="Position">The position of the reported error</param>
     internal record ReaderLoggerState(string Message, SexprPosition? Position);
 
-    public static class ReaderLoggerExtensions
+    /// <summary>
+    /// Extensions for common logging scenarios
+    /// </summary>
+    internal static class ReaderLoggerExtensions
     {
+        /// <summary>
+        /// Logs a parse error associated with the given position
+        /// </summary>
+        /// <typeparam name="T">Logger category type</typeparam>
+        /// <param name="logger">This ILogger</param>
+        /// <param name="msg">Message to log</param>
+        /// <param name="pos">Position to report</param>
         public static void LogParseError<T>(this ILogger<T> logger, string msg, SexprPosition? pos)
         {
             logger.Log(LogLevel.Error, default, new ReaderLoggerState(msg, pos), null, (s, e) => s.Message);
         }
 
+        /// <summary>
+        /// Logs a parse error and throws a parse exception
+        /// </summary>
+        /// <typeparam name="T">Logger category type</typeparam>
+        /// <param name="logger">This ILogger</param>
+        /// <param name="msg">Message to log</param>
+        /// <param name="pos">Position to report</param>
+        /// <returns>An exception</returns>
+        /// <exception cref="FatalParseException">Always thrown</exception>
         [DoesNotReturn]
-        public static void LogParseErrorAndThrow<T>(this ILogger<T> logger, string msg, SexprPosition? pos)
+        public static FatalParseException LogParseErrorAndThrow<T>(this ILogger<T> logger, string msg, SexprPosition? pos)
         {
             logger.LogParseError(msg, pos);
             throw new FatalParseException(msg, pos);
         }
     }
 
+    /// <summary>
+    /// Provider for the ReaderLogger
+    /// </summary>
     internal class ReaderLoggerProvider : ILoggerProvider
     {
+        /// <summary>
+        /// Singleton logger instance to use
+        /// </summary>
         private readonly ILogger _logger;
 
-        public ReaderLoggerProvider(TextWriter tw)
+        /// <summary>
+        /// Creates a new ReaderLoggerProvider
+        /// </summary>
+        /// <param name="scp">ISourceContextProvider for mapping positions to source contexts</param>
+        /// <param name="tw">TextWriter to write log messages to</param>
+        public ReaderLoggerProvider(ISourceContextProvider scp, TextWriter tw)
         {
-            _logger = new ReaderLogger(tw);
+            _logger = new ReaderLogger(scp, tw);
         }
 
+        /// <inheritdoc />
         public ILogger CreateLogger(string categoryName)
         {
             return _logger;
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
         }

--- a/ParserLibrary/Reader/SourceMap.cs
+++ b/ParserLibrary/Reader/SourceMap.cs
@@ -63,15 +63,10 @@ namespace Semgus.Parser.Reader
             }
 
             set
-            {   
-                try
-                {
-                    _sourceMap.Add(key, value);
-                }
-                catch (ArgumentException)
-                {
-                    throw new InvalidOperationException($"Attempt to add duplicate source key: {key}");
-                }
+            {
+                // Updating happens in cases like annotations, where converters just
+                // take the result of an existing conversion, modify it, and push it up
+                _sourceMap.AddOrUpdate(key, value);
             }
         }
     }

--- a/ParserLibrary/Reader/SourceMap.cs
+++ b/ParserLibrary/Reader/SourceMap.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.Extensions.Logging;
+
+using Semgus.Sexpr.Reader;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Semgus.Parser.Reader
+{
+    /// <summary>
+    /// Maps between parsed objects and their location in the source text
+    /// </summary>
+    internal class SourceMap : ISourceMap
+    {
+        /// <summary>
+        /// Table holding mappings between objects and positions. Note that
+        /// ConditionalWeakTable keys on reference, not value, and it doesn't
+        /// prevent the keys from being garbage collected.
+        /// </summary>
+        private readonly ConditionalWeakTable<object, SexprPosition> _sourceMap;
+
+        /// <summary>
+        /// Logger for logging
+        /// </summary>
+        private readonly ILogger<SourceMap> _logger;
+
+        /// <summary>
+        /// Creates a new SourceMap with the given logger
+        /// </summary>
+        /// <param name="logger">Logger to use</param>
+        public SourceMap(ILogger<SourceMap> logger)
+        {
+            _sourceMap = new ConditionalWeakTable<object, SexprPosition>();
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Gets or sets the position of a given object
+        /// </summary>
+        /// <param name="key">The object</param>
+        /// <returns>The object's position</returns>
+        /// <exception cref="InvalidOperationException">Thrown when a reference has a duplicate position added. This indicates a bug in the parser.</exception>
+        public SexprPosition this[object key]
+        {
+            get
+            {
+                if (_sourceMap.TryGetValue(key, out var position))
+                {
+                    return position;
+                }
+                else
+                {
+                    _logger.LogDebug($"Source not found for object: {key}");
+                    return SexprPosition.Default;
+                }
+            }
+
+            set
+            {   
+                try
+                {
+                    _sourceMap.Add(key, value);
+                }
+                catch (ArgumentException)
+                {
+                    throw new InvalidOperationException($"Attempt to add duplicate source key: {key}");
+                }
+            }
+        }
+    }
+}

--- a/ParserTests/Issues/Issue46.cs
+++ b/ParserTests/Issues/Issue46.cs
@@ -26,6 +26,13 @@ namespace Semgus.Parser.Tests.Issues
     /// </summary>
     public class Issue46
     {
+        private ISmtContextProvider FakeSmtCtx(SmtContext ctx)
+        {
+            var fake = A.Fake<ISmtContextProvider>();
+            A.CallTo(() => fake.Context).Returns(ctx);
+            return fake;
+        }
+
         [Fact]
         public void RejectsInvalidNullaryOp()
         {
@@ -38,14 +45,14 @@ namespace Semgus.Parser.Tests.Issues
             SemgusTermType tt = new(ttId);
             smtCtx.AddSortDeclaration(tt);
 
-            List<(SmtIdentifier, SmtSort)> ntMap = new()
+            List<(SmtIdentifier, SmtSortIdentifier)> ntMap = new()
             {
-                (ntId, tt)
+                (ntId, ttId)
             };
 
-            List<(SmtIdentifier, SmtSort, IList<SemgusToken>)> prods = new()
+            List<(SmtIdentifier, SmtSortIdentifier, IList<SemgusToken>)> prods = new()
             {
-                (ntId, tt, new List<SemgusToken>() { opSymbol })
+                (ntId, ttId, new List<SemgusToken>() { opSymbol })
             };
 
             SynthFunCommand.GrammarForm gf = new(ntMap, prods);
@@ -55,7 +62,7 @@ namespace Semgus.Parser.Tests.Issues
 
             SynthFunCommand sfc = new(
                 A.Fake<ISemgusProblemHandler>(),
-                A.Fake<ISmtContextProvider>(),
+                FakeSmtCtx(smtCtx),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
                 A.Fake<ISourceMap>(),
@@ -86,14 +93,14 @@ namespace Semgus.Parser.Tests.Issues
             tt.AddConstructor(new(opId, tt, tt));
             smtCtx.AddSortDeclaration(tt);
 
-            List<(SmtIdentifier, SmtSort)> ntMap = new()
+            List<(SmtIdentifier, SmtSortIdentifier)> ntMap = new()
             {
-                (ntId, tt)
+                (ntId, ttId)
             };
 
-            List<(SmtIdentifier, SmtSort, IList<SemgusToken>)> prods = new()
+            List<(SmtIdentifier, SmtSortIdentifier, IList<SemgusToken>)> prods = new()
             {
-                (ntId, tt, new List<SemgusToken>() { cons })
+                (ntId, ttId, new List<SemgusToken>() { cons })
             };
 
             SynthFunCommand.GrammarForm gf = new(ntMap, prods);
@@ -103,7 +110,7 @@ namespace Semgus.Parser.Tests.Issues
 
             SynthFunCommand sfc = new(
                 A.Fake<ISemgusProblemHandler>(),
-                A.Fake<ISmtContextProvider>(),
+                FakeSmtCtx(smtCtx),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
                 A.Fake<ISourceMap>(),
@@ -126,14 +133,14 @@ namespace Semgus.Parser.Tests.Issues
             tt.AddConstructor(new(opId, tt, tt));
             smtCtx.AddSortDeclaration(tt);
 
-            List<(SmtIdentifier, SmtSort)> ntMap = new()
+            List<(SmtIdentifier, SmtSortIdentifier)> ntMap = new()
             {
-                (ntId, tt)
+                (ntId, ttId)
             };
 
-            List<(SmtIdentifier, SmtSort, IList<SemgusToken>)> prods = new()
+            List<(SmtIdentifier, SmtSortIdentifier, IList<SemgusToken>)> prods = new()
             {
-                (ntId, tt, new List<SemgusToken>() { opSymbol })
+                (ntId, ttId, new List<SemgusToken>() { opSymbol })
             };
 
             SynthFunCommand.GrammarForm gf = new(ntMap, prods);
@@ -142,7 +149,7 @@ namespace Semgus.Parser.Tests.Issues
 
             SynthFunCommand sfc = new(
                 A.Fake<ISemgusProblemHandler>(),
-                A.Fake<ISmtContextProvider>(),
+                FakeSmtCtx(smtCtx),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
                 A.Fake<ISourceMap>(),

--- a/ParserTests/Issues/Issue46.cs
+++ b/ParserTests/Issues/Issue46.cs
@@ -30,7 +30,7 @@ namespace Semgus.Parser.Tests.Issues
         public void RejectsInvalidNullaryOp()
         {
             SmtIdentifier ntId = new("E");
-            SmtIdentifier ttId = new("Term");
+            SmtSortIdentifier ttId = new("Term");
             SmtIdentifier opId = new("op-that-does-not-exist");
             SymbolToken opSymbol = new(opId.Symbol, SexprPosition.Default);
 
@@ -58,6 +58,7 @@ namespace Semgus.Parser.Tests.Issues
                 A.Fake<ISmtContextProvider>(),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
+                A.Fake<ISourceMap>(),
                 A.Fake<ILogger<SynthFunCommand>>());
 
             Assert.Throws<FatalParseException>(() => sfc.CreateGrammarFromForm(gf));
@@ -67,7 +68,7 @@ namespace Semgus.Parser.Tests.Issues
         public void RejectsInvalidArity()
         {
             SmtIdentifier ntId = new("E");
-            SmtIdentifier ttId = new("Term");
+            SmtSortIdentifier ttId = new("Term");
             SmtIdentifier opId = new("op");
             SymbolToken opSymbol = new(opId.Symbol, SexprPosition.Default);
             SymbolToken ntSymbol = new(ntId.Symbol, SexprPosition.Default);
@@ -105,6 +106,7 @@ namespace Semgus.Parser.Tests.Issues
                 A.Fake<ISmtContextProvider>(),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
+                A.Fake<ISourceMap>(),
                 A.Fake<ILogger<SynthFunCommand>>());
 
             Assert.Throws<FatalParseException>(() => sfc.CreateGrammarFromForm(gf));
@@ -114,7 +116,7 @@ namespace Semgus.Parser.Tests.Issues
         public void RejectsMalformed()
         {
             SmtIdentifier ntId = new("E");
-            SmtIdentifier ttId = new("Term");
+            SmtSortIdentifier ttId = new("Term");
             SmtIdentifier opId = new("op");
             SymbolToken opSymbol = new(opId.Symbol, SexprPosition.Default);
 
@@ -143,6 +145,7 @@ namespace Semgus.Parser.Tests.Issues
                 A.Fake<ISmtContextProvider>(),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
+                A.Fake<ISourceMap>(),
                 A.Fake<ILogger<SynthFunCommand>>());
 
             Assert.Throws<FatalParseException>(() => sfc.CreateGrammarFromForm(gf));

--- a/ParserTests/Issues/Issue47.cs
+++ b/ParserTests/Issues/Issue47.cs
@@ -34,6 +34,13 @@ namespace Semgus.Parser.Tests.Issues
     /// </summary>
     public class Issue47
     {
+        private ISmtContextProvider FakeSmtCtx(SmtContext ctx)
+        {
+            var fake = A.Fake<ISmtContextProvider>();
+            A.CallTo(() => fake.Context).Returns(ctx);
+            return fake;
+        }
+
         [Fact]
         public void HandlesNtToNtProductions()
         {
@@ -45,14 +52,14 @@ namespace Semgus.Parser.Tests.Issues
             SemgusTermType tt = new(ttId);
             smtCtx.AddSortDeclaration(tt);
 
-            List<(SmtIdentifier, SmtSort)> ntMap = new()
+            List<(SmtIdentifier, SmtSortIdentifier)> ntMap = new()
             {
-                (ntId, tt)
+                (ntId, ttId)
             };
 
-            List<(SmtIdentifier, SmtSort, IList<SemgusToken>)> prods = new()
+            List<(SmtIdentifier, SmtSortIdentifier, IList<SemgusToken>)> prods = new()
             {
-                (ntId, tt, new List<SemgusToken>() { ntSymbol })
+                (ntId, ttId, new List<SemgusToken>() { ntSymbol })
             };
 
             SynthFunCommand.GrammarForm gf = new(ntMap, prods);
@@ -62,7 +69,7 @@ namespace Semgus.Parser.Tests.Issues
 
             SynthFunCommand sfc = new(
                 A.Fake<ISemgusProblemHandler>(),
-                A.Fake<ISmtContextProvider>(),
+                FakeSmtCtx(smtCtx),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
                 A.Fake<ISourceMap>(),
@@ -91,15 +98,15 @@ namespace Semgus.Parser.Tests.Issues
             SemgusTermType tt = new(ttId);
             smtCtx.AddSortDeclaration(tt);
 
-            List<(SmtIdentifier, SmtSort)> ntMap = new()
+            List<(SmtIdentifier, SmtSortIdentifier)> ntMap = new()
             {
-                (nt1Id, tt),
-                (nt2Id, tt)
+                (nt1Id, ttId),
+                (nt2Id, ttId)
             };
 
-            List<(SmtIdentifier, SmtSort, IList<SemgusToken>)> prods = new()
+            List<(SmtIdentifier, SmtSortIdentifier, IList<SemgusToken>)> prods = new()
             {
-                (nt1Id, tt, new List<SemgusToken>() { nt2Symbol })
+                (nt1Id, ttId, new List<SemgusToken>() { nt2Symbol })
             };
 
             SynthFunCommand.GrammarForm gf = new(ntMap, prods);
@@ -109,7 +116,7 @@ namespace Semgus.Parser.Tests.Issues
 
             SynthFunCommand sfc = new(
                 A.Fake<ISemgusProblemHandler>(),
-                A.Fake<ISmtContextProvider>(),
+                FakeSmtCtx(smtCtx),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
                 A.Fake<ISourceMap>(),
@@ -141,15 +148,15 @@ namespace Semgus.Parser.Tests.Issues
             smtCtx.AddSortDeclaration(tt1);
             smtCtx.AddSortDeclaration(tt2);
 
-            List<(SmtIdentifier, SmtSort)> ntMap = new()
+            List<(SmtIdentifier, SmtSortIdentifier)> ntMap = new()
             {
-                (nt1Id, tt1),
-                (nt2Id, tt2)
+                (nt1Id, tt1Id),
+                (nt2Id, tt2Id)
             };
 
-            List<(SmtIdentifier, SmtSort, IList<SemgusToken>)> prods = new()
+            List<(SmtIdentifier, SmtSortIdentifier, IList<SemgusToken>)> prods = new()
             {
-                (nt1Id, tt1, new List<SemgusToken>() { nt2Symbol })
+                (nt1Id, tt1Id, new List<SemgusToken>() { nt2Symbol })
             };
 
             SynthFunCommand.GrammarForm gf = new(ntMap, prods);
@@ -159,7 +166,7 @@ namespace Semgus.Parser.Tests.Issues
 
             SynthFunCommand sfc = new(
                 A.Fake<ISemgusProblemHandler>(),
-                A.Fake<ISmtContextProvider>(),
+                FakeSmtCtx(smtCtx),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
                 A.Fake<ISourceMap>(),
@@ -180,14 +187,14 @@ namespace Semgus.Parser.Tests.Issues
             tt.AddConstructor(new(ntId));
             smtCtx.AddSortDeclaration(tt);
 
-            List<(SmtIdentifier, SmtSort)> ntMap = new()
+            List<(SmtIdentifier, SmtSortIdentifier)> ntMap = new()
             {
-                (ntId, tt)
+                (ntId, ttId)
             };
 
-            List<(SmtIdentifier, SmtSort, IList<SemgusToken>)> prods = new()
+            List<(SmtIdentifier, SmtSortIdentifier, IList<SemgusToken>)> prods = new()
             {
-                (ntId, tt, new List<SemgusToken>() { ntSymbol })
+                (ntId, ttId, new List<SemgusToken>() { ntSymbol })
             };
 
             SynthFunCommand.GrammarForm gf = new(ntMap, prods);
@@ -197,7 +204,7 @@ namespace Semgus.Parser.Tests.Issues
 
             SynthFunCommand sfc = new(
                 A.Fake<ISemgusProblemHandler>(),
-                A.Fake<ISmtContextProvider>(),
+                FakeSmtCtx(smtCtx),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
                 A.Fake<ISourceMap>(),
@@ -228,15 +235,15 @@ namespace Semgus.Parser.Tests.Issues
             SemgusTermType tt = new(ttId);
             smtCtx.AddSortDeclaration(tt);
 
-            List<(SmtIdentifier, SmtSort)> ntMap = new()
+            List<(SmtIdentifier, SmtSortIdentifier)> ntMap = new()
             {
-                (nt1Id, tt),
-                (nt2Id, tt)
+                (nt1Id, ttId),
+                (nt2Id, ttId)
             };
 
-            List<(SmtIdentifier, SmtSort, IList<SemgusToken>)> prods = new()
+            List<(SmtIdentifier, SmtSortIdentifier, IList<SemgusToken>)> prods = new()
             {
-                (nt1Id, tt, new List<SemgusToken>() { nt2Symbol })
+                (nt1Id, ttId, new List<SemgusToken>() { nt2Symbol })
             };
 
             SynthFunCommand.GrammarForm gf = new(ntMap, prods);
@@ -246,7 +253,7 @@ namespace Semgus.Parser.Tests.Issues
 
             SynthFunCommand sfc = new(
                 A.Fake<ISemgusProblemHandler>(),
-                A.Fake<ISmtContextProvider>(),
+                FakeSmtCtx(smtCtx),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
                 A.Fake<ISourceMap>(),

--- a/ParserTests/Issues/Issue47.cs
+++ b/ParserTests/Issues/Issue47.cs
@@ -38,7 +38,7 @@ namespace Semgus.Parser.Tests.Issues
         public void HandlesNtToNtProductions()
         {
             SmtIdentifier ntId = new("nt");
-            SmtIdentifier ttId = new("Term");
+            SmtSortIdentifier ttId = new("Term");
             SymbolToken ntSymbol = new(ntId.Symbol, SexprPosition.Default);
 
             SmtContext smtCtx = new();
@@ -65,6 +65,7 @@ namespace Semgus.Parser.Tests.Issues
                 A.Fake<ISmtContextProvider>(),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
+                A.Fake<ISourceMap>(),
                 A.Fake<ILogger<SynthFunCommand>>());
 
             SemgusGrammar grammar = sfc.CreateGrammarFromForm(gf);
@@ -83,7 +84,7 @@ namespace Semgus.Parser.Tests.Issues
         {
             SmtIdentifier nt1Id = new("E");
             SmtIdentifier nt2Id = new("A");
-            SmtIdentifier ttId = new("Term");
+            SmtSortIdentifier ttId = new("Term");
             SymbolToken nt2Symbol = new(nt2Id.Symbol, SexprPosition.Default);
 
             SmtContext smtCtx = new();
@@ -111,6 +112,7 @@ namespace Semgus.Parser.Tests.Issues
                 A.Fake<ISmtContextProvider>(),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
+                A.Fake<ISourceMap>(),
                 A.Fake<ILogger<SynthFunCommand>>());
 
             SemgusGrammar grammar = sfc.CreateGrammarFromForm(gf);
@@ -129,8 +131,8 @@ namespace Semgus.Parser.Tests.Issues
         {
             SmtIdentifier nt1Id = new("E");
             SmtIdentifier nt2Id = new("A");
-            SmtIdentifier tt1Id = new("Term1");
-            SmtIdentifier tt2Id = new("Term2");
+            SmtSortIdentifier tt1Id = new("Term1");
+            SmtSortIdentifier tt2Id = new("Term2");
             SymbolToken nt2Symbol = new(nt2Id.Symbol, SexprPosition.Default);
 
             SmtContext smtCtx = new();
@@ -160,6 +162,7 @@ namespace Semgus.Parser.Tests.Issues
                 A.Fake<ISmtContextProvider>(),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
+                A.Fake<ISourceMap>(),
                 A.Fake<ILogger<SynthFunCommand>>());
 
             Assert.Throws<FatalParseException>(() => sfc.CreateGrammarFromForm(gf));
@@ -169,7 +172,7 @@ namespace Semgus.Parser.Tests.Issues
         public void OverridesNullaryConstructors()
         {
             SmtIdentifier ntId = new("nt");
-            SmtIdentifier ttId = new("Term");
+            SmtSortIdentifier ttId = new("Term");
             SymbolToken ntSymbol = new(ntId.Symbol, SexprPosition.Default);
 
             SmtContext smtCtx = new();
@@ -197,6 +200,7 @@ namespace Semgus.Parser.Tests.Issues
                 A.Fake<ISmtContextProvider>(),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
+                A.Fake<ISourceMap>(),
                 A.Fake<ILogger<SynthFunCommand>>());
 
             SemgusGrammar grammar = sfc.CreateGrammarFromForm(gf);
@@ -217,7 +221,7 @@ namespace Semgus.Parser.Tests.Issues
             SmtIdentifier nt1Id = new("E");
             SmtIdentifier nt2Id = new("A");
             SmtIdentifier bogusId = new("Bogus");
-            SmtIdentifier ttId = new("Term");
+            SmtSortIdentifier ttId = new("Term");
             SymbolToken nt2Symbol = new(bogusId.Symbol, SexprPosition.Default);
 
             SmtContext smtCtx = new();
@@ -245,6 +249,7 @@ namespace Semgus.Parser.Tests.Issues
                 A.Fake<ISmtContextProvider>(),
                 A.Fake<ISemgusContextProvider>(),
                 converter,
+                A.Fake<ISourceMap>(),
                 A.Fake<ILogger<SynthFunCommand>>());
 
             Assert.Throws<FatalParseException>(() => sfc.CreateGrammarFromForm(gf));

--- a/Semgus-Lib/Model/SemgusTermType.cs
+++ b/Semgus-Lib/Model/SemgusTermType.cs
@@ -10,7 +10,7 @@ namespace Semgus.Model
 {
     public class SemgusTermType : SmtSort
     {
-        public SemgusTermType(SmtIdentifier termname) : base(termname) { }
+        public SemgusTermType(SmtSortIdentifier termname) : base(termname) { }
         public IList<Constructor> Constructors { get; } = new List<Constructor>();
         public void AddConstructor(Constructor constructor)
         {

--- a/Semgus-Lib/Model/Smt/SmtSort.cs
+++ b/Semgus-Lib/Model/Smt/SmtSort.cs
@@ -9,12 +9,12 @@ namespace Semgus.Model.Smt
 {
     public abstract class SmtSort
     {
-        public SmtSort(SmtIdentifier name)
+        public SmtSort(SmtSortIdentifier name)
         {
             Name = name;
         }
 
-        public SmtIdentifier Name { get; }
+        public SmtSortIdentifier Name { get; }
 
         /// <summary>
         /// Does this sort have parameters?
@@ -28,7 +28,7 @@ namespace Semgus.Model.Smt
 
         private class GenericSort : SmtSort
         {
-            public GenericSort(SmtIdentifier name) : base(name)
+            public GenericSort(SmtSortIdentifier name) : base(name)
             { }
         }
 
@@ -36,7 +36,7 @@ namespace Semgus.Model.Smt
         {
             private class UniqueSort : SmtSort
             {
-                public UniqueSort(string prefix, long counter) : base(new SmtIdentifier($"{prefix}{counter}"))
+                public UniqueSort(string prefix, long counter) : base(new SmtSortIdentifier($"{prefix}{counter}"))
                 {
                     IsSortParameter = true;
                 }

--- a/Semgus-Lib/Model/Smt/SmtSortIdentifier.cs
+++ b/Semgus-Lib/Model/Smt/SmtSortIdentifier.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Semgus.Model.Smt
+{
+    /// <summary>
+    /// Symbolic representation of a sort
+    /// </summary>
+    /// <param name="Name">The name of this sort</param>
+    /// <param name="Parameters">Sort parameters for this sort</param>
+    public sealed record SmtSortIdentifier(SmtIdentifier Name, params SmtSortIdentifier[] Parameters)
+    {
+        /// <summary>
+        /// Creates a new simple SmtSortIdentifier with the given name (as a string)
+        /// </summary>
+        /// <param name="name">The string name</param>
+        public SmtSortIdentifier(string name) : this(new SmtIdentifier(name))
+        {
+        }
+
+        /// <summary>
+        /// Gets the number of parameters this sort uses
+        /// </summary>
+        public int Arity => Parameters.Length;
+
+        /// <summary>
+        /// Checks if this sort identifier represents the same sort as the other 
+        /// </summary>
+        /// <param name="other">Sort identifier to check against</param>
+        /// <returns>True if the same sort</returns>
+        public bool Equals(SmtSortIdentifier? other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+            return Parameters.Length == other.Parameters.Length
+                && Name == other.Name
+                && Parameters.SequenceEqual(other.Parameters);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 23 + Name.GetHashCode();
+                foreach (SmtSortIdentifier s in Parameters)
+                {
+                    hash = hash * 23 + s.GetHashCode();
+                }
+                return hash;
+            }
+        }
+    }
+}

--- a/Semgus-Lib/Model/Smt/SmtSortIdentifier.cs
+++ b/Semgus-Lib/Model/Smt/SmtSortIdentifier.cs
@@ -60,5 +60,18 @@ namespace Semgus.Model.Smt
                 return hash;
             }
         }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            if (Parameters.Length == 0)
+            {
+                return Name.ToString();
+            }
+            else
+            {
+                return $"({Name} {string.Join(' ', Parameters.Select(p => p.ToString()))})";
+            }
+        }
     }
 }

--- a/Semgus-Lib/Model/Smt/SmtTheory.cs
+++ b/Semgus-Lib/Model/Smt/SmtTheory.cs
@@ -10,26 +10,26 @@ namespace Semgus.Model.Smt
 {
     public abstract class SmtTheory
     {
-        public static SmtTheory Core;
+        public static SmtTheory Core = null!;
 
-        public static SmtTheory Ints;
+        public static SmtTheory Ints = null!;
 
-        public static SmtTheory Reals;
+        public static SmtTheory Reals = null!;
 
-        public static SmtTheory Reals_Ints;
+        public static SmtTheory Reals_Ints = null!;
 
-        public static SmtTheory FloatingPoint;
+        public static SmtTheory FloatingPoint = null!;
 
-        public static SmtTheory Strings;
+        public static SmtTheory Strings = null!;
 
-        public static SmtTheory FixedSizeBitVectors;
+        public static SmtTheory FixedSizeBitVectors = null!;
 
-        public static SmtTheory ArraysEx;
+        public static SmtTheory ArraysEx = null!;
 
         /// <summary>
         /// Everything that is defined by the user in a problem
         /// </summary>
-        public static SmtTheory UserDefined;
+        public static SmtTheory UserDefined = null!;
 
         public abstract IReadOnlyDictionary<SmtIdentifier, SmtSort> Sorts { get; }
         public abstract IReadOnlyDictionary<SmtIdentifier, SmtFunction> Functions { get; }

--- a/Semgus-Lib/Model/Smt/Terms/SmtLiteral.cs
+++ b/Semgus-Lib/Model/Smt/Terms/SmtLiteral.cs
@@ -8,65 +8,142 @@ using System.Threading.Tasks;
 
 namespace Semgus.Model.Smt.Terms
 {
+    /// <summary>
+    /// Top-level class of literal SMT terms
+    /// </summary>
     public abstract class SmtLiteral : SmtTerm
     {
+        /// <summary>
+        /// Resolves the given sort for a literal
+        /// </summary>
+        /// <param name="ctx">SmtContext</param>
+        /// <param name="name">Literal sort identifier</param>
+        /// <returns>The resolved sort</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the literal sort cannot be found</exception>
+        protected static SmtSort GetSortOrDie(SmtContext ctx, SmtSortIdentifier name)
+        {
+            if (!ctx.TryGetSortDeclaration(name, out var sort))
+            {
+                throw new InvalidOperationException("Failed to get sort for literal: " + name);
+            }
+            return sort;
+        }
+
+        /// <summary>
+        /// Base constructor for literals of the given sort 
+        /// </summary>
+        /// <param name="sort">Literal sort</param>
         public SmtLiteral(SmtSort sort) : base(sort) { }
     }
 
+    /// <summary>
+    /// Literals for numerals (integers)
+    /// </summary>
     public class SmtNumeralLiteral : SmtLiteral
     {
+        /// <summary>
+        /// The literal value
+        /// </summary>
         public long Value { get; }
 
-        public SmtNumeralLiteral(SmtContext ctx, long value) : base(ctx.GetSortDeclaration(new SmtIdentifier("Int")))
+        /// <summary>
+        /// Constructs a new numeral literal with the given value
+        /// </summary>
+        /// <param name="ctx">Current SMT context</param>
+        /// <param name="value">Literal value</param>
+        public SmtNumeralLiteral(SmtContext ctx, long value) : base(GetSortOrDie(ctx, new("Int")))
         {
             Value = value;
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Value.ToString();
         }
 
+        /// <summary>
+        /// Accepts a visitor for this term
+        /// </summary>
+        /// <typeparam name="TOutput">Visitation output type</typeparam>
+        /// <param name="visitor">The visitor</param>
+        /// <returns>Output of the visitor</returns>
         public override TOutput Accept<TOutput>(ISmtTermVisitor<TOutput> visitor)
         {
             return visitor.VisitNumeralLiteral(this);
         }
     }
 
+    /// <summary>
+    /// Literals for decimals (reals)
+    /// </summary>
     public class SmtDecimalLiteral : SmtLiteral
     {
+        /// <summary>
+        /// The literal value
+        /// </summary>
         public double Value { get; }
 
-        public SmtDecimalLiteral(SmtContext ctx, double value) : base(ctx.GetSortDeclaration(new SmtIdentifier("Real")))
+        /// <summary>
+        /// Constructs a new decimal literal with the given value
+        /// </summary>
+        /// <param name="ctx">Current SMT context</param>
+        /// <param name="value">Literal value</param>
+        public SmtDecimalLiteral(SmtContext ctx, double value) : base(GetSortOrDie(ctx, new("Real")))
         {
             Value = value;
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return Value.ToString();
         }
 
+        /// <summary>
+        /// Accepts a visitor for this term
+        /// </summary>
+        /// <typeparam name="TOutput">Visitation output type</typeparam>
+        /// <param name="visitor">The visitor</param>
+        /// <returns>Output of the visitor</returns>
         public override TOutput Accept<TOutput>(ISmtTermVisitor<TOutput> visitor)
         {
             return visitor.VisitDecimalLiteral(this);
         }
     }
 
+    /// <summary>
+    /// Literals for strings
+    /// </summary>
     public class SmtStringLiteral : SmtLiteral
     {
+        /// <summary>
+        /// The literal value
+        /// </summary>
         public string Value { get; }
 
-        public SmtStringLiteral(SmtContext ctx, string value) : base(ctx.GetSortDeclaration(new SmtIdentifier("String")))
+        /// <summary>
+        /// Constructs a new string literal with the given value
+        /// </summary>
+        /// <param name="ctx">Current SMT context</param>
+        /// <param name="value">Literal value</param>
+        public SmtStringLiteral(SmtContext ctx, string value) : base(GetSortOrDie(ctx, new("String")))
         {
             Value = value;
         }
 
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"\"{Value}\"";
         }
 
+        /// <summary>
+        /// Accepts a visitor for this term
+        /// </summary>
+        /// <typeparam name="TOutput">Visitation output type</typeparam>
+        /// <param name="visitor">The visitor</param>
+        /// <returns>Output of the visitor</returns>
         public override TOutput Accept<TOutput>(ISmtTermVisitor<TOutput> visitor)
         {
             return visitor.VisitStringLiteral(this);

--- a/Semgus-Lib/Model/Smt/Theories/SmtCoreTheory.cs
+++ b/Semgus-Lib/Model/Smt/Theories/SmtCoreTheory.cs
@@ -10,7 +10,7 @@ namespace Semgus.Model.Smt.Theories
     {
         private class BoolSort : SmtSort
         {
-            private BoolSort() : base(new SmtIdentifier("Bool")) { }
+            private BoolSort() : base(new SmtSortIdentifier("Bool")) { }
             public static BoolSort Instance { get; } = new();
         }
 
@@ -37,7 +37,7 @@ namespace Semgus.Model.Smt.Theories
                 }
             }
 
-            _boolSortList = new Dictionary<SmtIdentifier, SmtSort>() { { b.Name, b } };
+            _boolSortList = new Dictionary<SmtIdentifier, SmtSort>() { { b.Name.Name, b } };
 
             cf("true", b);
             cf("false", b);

--- a/Semgus-Lib/Model/Smt/Theories/SmtIntsTheory.cs
+++ b/Semgus-Lib/Model/Smt/Theories/SmtIntsTheory.cs
@@ -10,7 +10,7 @@ namespace Semgus.Model.Smt.Theories
     {
         private class IntSort : SmtSort
         {
-            private IntSort() : base(new SmtIdentifier("Int")) { }
+            private IntSort() : base(new SmtSortIdentifier("Int")) { }
             public static IntSort Instance { get; } = new();
         }
 
@@ -37,7 +37,7 @@ namespace Semgus.Model.Smt.Theories
                 }
             }
 
-            _intSortList = new Dictionary<SmtIdentifier, SmtSort>() { { i.Name, i } };
+            _intSortList = new Dictionary<SmtIdentifier, SmtSort>() { { i.Name.Name, i } };
 
             cf("-", i, i); // Negation
             cf("-", i, i, i); // Subtraction

--- a/Semgus-Lib/Model/Smt/Theories/SmtStringsTheory.cs
+++ b/Semgus-Lib/Model/Smt/Theories/SmtStringsTheory.cs
@@ -10,7 +10,7 @@ namespace Semgus.Model.Smt.Theories
     {
         private class StringSort : SmtSort
         {
-            private StringSort() : base(new SmtIdentifier("String")) { }
+            private StringSort() : base(new SmtSortIdentifier("String")) { }
             public static StringSort Instance { get; } = new();
         }
 
@@ -38,7 +38,7 @@ namespace Semgus.Model.Smt.Theories
                 }
             }
 
-            _stringSortList = new Dictionary<SmtIdentifier, SmtSort>() { { s.Name, s } };
+            _stringSortList = new Dictionary<SmtIdentifier, SmtSort>() { { s.Name.Name, s } };
 
             // TODO: regular expression functions
             cf("str.++", s, s, s);

--- a/SemgusParser/Json/ChcEvent.cs
+++ b/SemgusParser/Json/ChcEvent.cs
@@ -36,6 +36,6 @@ namespace Semgus.Parser.Json
             }
         }
 
-        public record ConstructorModel(SmtIdentifier Name, IEnumerable<SmtIdentifier> Arguments, IEnumerable<SmtIdentifier> ArgumentSorts, SmtIdentifier ReturnSort);
+        public record ConstructorModel(SmtIdentifier Name, IEnumerable<SmtIdentifier> Arguments, IEnumerable<SmtSortIdentifier> ArgumentSorts, SmtSortIdentifier ReturnSort);
     }
 }

--- a/SemgusParser/Json/Converters/SmtSortIdentifierConverter.cs
+++ b/SemgusParser/Json/Converters/SmtSortIdentifierConverter.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json;
+
+using Semgus.Model.Smt;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Semgus.Parser.Json.Converters
+{
+    internal class SmtSortIdentifierConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(SmtSortIdentifier);
+        }
+
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            if (value is not SmtSortIdentifier id)
+            {
+                throw new InvalidOperationException("Attepted to serialize the wrong thing.");
+            }
+
+            if (id.Parameters.Length > 0)
+            {
+                throw new InvalidOperationException("Parameterized sorts not yet supported by the JSON serializer.");
+            }
+            else
+            {
+                serializer.Serialize(writer, id.Name);
+            }            
+        }
+    }
+}

--- a/SemgusParser/Json/Converters/SmtTermConverter.cs
+++ b/SemgusParser/Json/Converters/SmtTermConverter.cs
@@ -61,8 +61,8 @@ namespace Semgus.Parser.Json.Converters
             }
 
             private record FunctionApplicationModel(SmtIdentifier Name,
-                                                    SmtIdentifier ReturnSort,
-                                                    IEnumerable<SmtIdentifier> ArgumentSorts,
+                                                    SmtSortIdentifier ReturnSort,
+                                                    IEnumerable<SmtSortIdentifier> ArgumentSorts,
                                                     IEnumerable<SmtTerm> Arguments) : TermModel("application");
             public object VisitFunctionApplication(SmtFunctionApplication functionApplication)
             {
@@ -87,7 +87,7 @@ namespace Semgus.Parser.Json.Converters
                 return this;
             }
 
-            private record VariableModel(SmtIdentifier Name, SmtIdentifier Sort) : TermModel("variable");
+            private record VariableModel(SmtIdentifier Name, SmtSortIdentifier Sort) : TermModel("variable");
             public object VisitVariable(SmtVariable variable)
             {
                 _serializer.Serialize(_writer, new VariableModel(Name: variable.Name, Sort: variable.Sort.Name));

--- a/SemgusParser/Json/JsonHandler.cs
+++ b/SemgusParser/Json/JsonHandler.cs
@@ -29,6 +29,7 @@ namespace Semgus.Parser.Json
             _serializer.Converters.Add(new SemanticRelationConverter());
             _serializer.Converters.Add(new SmtTermConverter());
             _serializer.Converters.Add(new SmtAttributeValueConverter());
+            _serializer.Converters.Add(new SmtSortIdentifierConverter());
             _writer = writer;
             _processingMode = mode;
             if (_processingMode == Program.ProcessingMode.Batch)

--- a/SemgusParser/Json/SynthFunEvent.cs
+++ b/SemgusParser/Json/SynthFunEvent.cs
@@ -18,8 +18,8 @@ namespace Semgus.Parser.Json
         public SynthFunEvent(SemgusSynthFun ssf) : base("synth-fun", "semgus")
         {
             Name = ssf.Relation.Name;
-            TermType = ssf.Rank.ReturnSort.Name;
-            Grammar = new GrammarModel(ssf.Grammar.NonTerminals.Select(n => new NonTerminalDeclarationModel(n.Name, n.Sort.Name)),
+            TermType = ssf.Rank.ReturnSort.Name.Name;
+            Grammar = new GrammarModel(ssf.Grammar.NonTerminals.Select(n => new NonTerminalDeclarationModel(n.Name, n.Sort.Name.Name)),
                                        ssf.Grammar.Productions.Select(p => new ProductionModel(p.Instance.Name,
                                                                                                p.Constructor?.Operator,
                                                                                                p.Occurrences.Select(o => o?.Name))));

--- a/SemgusParser/Json/TermTypeEvents.cs
+++ b/SemgusParser/Json/TermTypeEvents.cs
@@ -11,7 +11,7 @@ namespace Semgus.Parser.Json
 {
     internal class TermTypeDeclarationEvent : ParseEvent
     {
-        public SmtIdentifier Name { get; }
+        public SmtSortIdentifier Name { get; }
         public TermTypeDeclarationEvent(SemgusTermType tt) : base("declare-term-type", "semgus")
         {
             Name = tt.Name;
@@ -20,7 +20,7 @@ namespace Semgus.Parser.Json
 
     internal class TermTypeDefinitionEvent : ParseEvent
     {
-        public SmtIdentifier Name { get; }
+        public SmtSortIdentifier Name { get; }
         public IEnumerable<ConstructorModel> Constructors { get; }
          
         public TermTypeDefinitionEvent(SemgusTermType tt) : base("define-term-type", "semgus")
@@ -28,6 +28,6 @@ namespace Semgus.Parser.Json
             Name = tt.Name;
             Constructors = tt.Constructors.Select(c => new ConstructorModel(c.Operator, c.Children.Select(x => x.Name)));
         }
-        public record ConstructorModel(SmtIdentifier Name, IEnumerable<SmtIdentifier> Children);
+        public record ConstructorModel(SmtIdentifier Name, IEnumerable<SmtSortIdentifier> Children);
     }
 }

--- a/SemgusParser/Program.cs
+++ b/SemgusParser/Program.cs
@@ -146,17 +146,17 @@ namespace Semgus.Parser
                 writer.Flush();
                 stream.Position = 0;
                 friendlyName = "test input";
-                return new(stream, "string");
+                return new SemgusParser(stream, "string");
             }
             else if (input == "-")
             {
                 friendlyName = "standard input";
-                return new(Console.In, "stdin");
+                return new SemgusParser(Console.In, "stdin");
             }
             else
             {
                 friendlyName = input;
-                return new(input);
+                return new SemgusParser(input);
             }
         }
 

--- a/SemgusParser/Verifier/VerificationHandler.cs
+++ b/SemgusParser/Verifier/VerificationHandler.cs
@@ -28,7 +28,7 @@ namespace Semgus.Parser.Verifier
             _writer.WriteLine("declare-term-types: ");
             foreach (var tt in termTypes)
             {
-                _writer.Write("  " + tt.Name.Symbol + " -->");
+                _writer.Write("  " + tt.Name + " -->");
                 bool firstConstructor = true;
                 foreach (var cons in tt.Constructors)
                 {


### PR DESCRIPTION
This PR improves error position tracking to the point where we can now get specific source locations for pretty much everything, fixing #51. Some major refactoring was necessary to make this work:
* `SmtSort`s are now no longer valid targets for `ISmtConverter`. Use `SmtSortIdentifier` instead.
* Revamped `SmtSort` interface on `SmtContext`, supporting usage of `SmtSortIdentifier`
* New `ISourceMap` interface, mapping between converted objects and their file positions
* New `ISourceContextProvider` interface, so the `ReaderLogger` can now print out the file line the error occurred on

Switching from `SmtSort` to `SmtSortIdentifier` in the converters was necessary so that we could return a unique record object for each conversion (meaning it can have a unique position), instead of returning a shared `SmtSort` object. This also allowed improving error messaging around undeclared `SmtSort`s, fixing #44, and matching how we handle function declarations.

Based on the substantial improvements here, I'm going to call #12 as fixed, too.