### PR TITLE
Report better errors for constraints

### DIFF
--- a/ParserLibrary/Commands/ConstraintCommand.cs
+++ b/ParserLibrary/Commands/ConstraintCommand.cs
@@ -42,11 +42,11 @@ namespace Semgus.Parser.Commands
             }
             else if (predicate.Sort == ErrorSort.Instance)
             {
-                throw new InvalidOperationException("Term in constraint is in error state: " + predicate);
+                throw _logger.LogParseErrorAndThrow("Term in constraint is in an error state due to previous errors: " + predicate, _sourceMap[predicate]);
             }
             else
             {
-                throw new InvalidOperationException("Term in constraint is not of Bool sort: " + predicate);
+                throw _logger.LogParseErrorAndThrow("Term in constraint is not of Bool sort: " + predicate, _sourceMap[predicate]);
             }
         }
         

--- a/ParserLibrary/Reader/ErrorSort.cs
+++ b/ParserLibrary/Reader/ErrorSort.cs
@@ -13,7 +13,14 @@ namespace Semgus.Parser.Reader
     /// </summary>
     internal class ErrorSort : SmtSort
     {
+        /// <summary>
+        /// Singleton instance of the error sort
+        /// </summary>
         public static ErrorSort Instance { get; } = new ErrorSort();
+
+        /// <summary>
+        /// Constructs an error sort
+        /// </summary>
         private ErrorSort() : base(new SmtSortIdentifier("@error")) { }
     }
 }

--- a/ParserLibrary/Reader/ErrorTerm.cs
+++ b/ParserLibrary/Reader/ErrorTerm.cs
@@ -8,18 +8,43 @@ using Semgus.Model.Smt.Terms;
 
 namespace Semgus.Parser.Reader
 {
+    /// <summary>
+    /// Term used by the parser to indicate that an error happened at a lower level.
+    /// This lets errors propagate upward during term parsing, so we can try and get
+    /// more information parsed out of the problem instead of failing fast.
+    /// </summary>
     internal class ErrorTerm : SmtTerm
     {
+        /// <summary>
+        /// Why this term is in error
+        /// </summary>
         public string Message { get; }
 
+        /// <summary>
+        /// Constructs a new error term with the given message
+        /// </summary>
+        /// <param name="message">Why this term is in error</param>
         public ErrorTerm(string message) : base(ErrorSort.Instance)
         {
             Message = message;
         }
 
+        /// <summary>
+        /// Accepts a visitor for this term. Always throws an exception.
+        /// </summary>
+        /// <typeparam name="TOutput">Visitor output type</typeparam>
+        /// <param name="visitor">Visitor to accept</param>
+        /// <returns>Does not return</returns>
+        /// <exception cref="InvalidOperationException">Always thrown, as visiting an error term is an error.</exception>
         public override TOutput Accept<TOutput>(ISmtTermVisitor<TOutput> visitor)
         {
             throw new InvalidOperationException("Visiting an error term.");
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return "<error>";
         }
     }
 }

--- a/ParserTests/Issues/Issue43.cs
+++ b/ParserTests/Issues/Issue43.cs
@@ -1,0 +1,71 @@
+﻿using FakeItEasy;
+
+using Microsoft.Extensions.Logging;
+
+using Semgus.Model.Smt;
+using Semgus.Model.Smt.Terms;
+using Semgus.Parser.Commands;
+using Semgus.Parser.Reader;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Semgus.Parser.Tests.Issues
+{
+    /// <summary>
+    /// https://github.com/SemGuS-git/Semgus-Parser/issues/43
+    /// The constraint command evidently just dumps a nasty stack trace
+    /// when the term is in an error state. This should be cleaned up to not be terrible.
+    /// </summary>
+    public class Issue43
+    {
+        [Fact]
+        public void ThrowsParseExceptionInErrorState()
+        {
+            ConstraintCommand cc = new(
+                A.Fake<ISemgusProblemHandler>(),
+                A.Fake<ISmtContextProvider>(),
+                A.Fake<ISemgusContextProvider>(),
+                A.Fake<ISourceMap>(),
+                A.Fake<ILogger<ConstraintCommand>>());
+
+            Assert.Throws<FatalParseException>(() => cc.Constraint(new ErrorTerm("test")));
+        }
+
+        [Fact]
+        public void ThrowsParseExceptionForNonBool()
+        {
+            ConstraintCommand cc = new(
+                A.Fake<ISemgusProblemHandler>(),
+                A.Fake<ISmtContextProvider>(),
+                A.Fake<ISemgusContextProvider>(),
+                A.Fake<ISourceMap>(),
+                A.Fake<ILogger<ConstraintCommand>>());
+
+            Assert.Throws<FatalParseException>(() => cc.Constraint(new SmtStringLiteral(new SmtContext(), "test")));
+        }
+
+        [Fact]
+        public void DoesNotThrowParseExceptionForBool()
+        {
+            ConstraintCommand cc = new(
+                A.Fake<ISemgusProblemHandler>(),
+                A.Fake<ISmtContextProvider>(),
+                A.Fake<ISemgusContextProvider>(),
+                A.Fake<ISourceMap>(),
+                A.Fake<ILogger<ConstraintCommand>>());
+
+            SmtContext ctx = new();
+            Assert.True(ctx.TryGetFunctionDeclaration(new("true"), out var truefn));
+            Assert.True(truefn!.TryResolveRank(out var rank, default));
+
+            // Should not throw
+            cc.Constraint(new SmtFunctionApplication(truefn, rank!, new List<SmtTerm>()));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #43. We now properly report errors in constraint terms instead of dumping an exception backtrace.