### PR TITLE
Make 'did-you-mean' facility better

### DIFF
--- a/ParserLibrary/Commands/ConstraintCommand.cs
+++ b/ParserLibrary/Commands/ConstraintCommand.cs
@@ -42,9 +42,11 @@ namespace Semgus.Parser.Commands
                 _semgusProvider.Context.AddConstraint(predicate);
                 _problemHandler.OnConstraint(_smtProvider.Context, _semgusProvider.Context, predicate);
             }
-            else if (predicate.Sort == ErrorSort.Instance)
+            else if (predicate.Sort == ErrorSort.Instance || predicate.Accept(new TermErrorSearcher()))
             {
-                throw _logger.LogParseErrorAndThrow("Term in constraint is in an error state due to previous errors: " + predicate, _sourceMap[predicate]);
+                // No need to log the error again, since it should have been logged
+                // when the error term was originally encountered. This is just noise.
+                throw new FatalParseException("Term in constraint is in an error state due to previous errors: " + predicate, _sourceMap[predicate]);
             }
             else
             {

--- a/ParserLibrary/Reader/DidYouMean.cs
+++ b/ParserLibrary/Reader/DidYouMean.cs
@@ -1,0 +1,127 @@
+﻿using Semgus.Model.Smt;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Semgus.Parser.Reader
+{
+    /// <summary>
+    /// Suggestion generator based on edit distance between identifiers
+    /// </summary>
+    internal class DidYouMean : ISuggestionGenerator
+    {
+        /// <summary>
+        /// Maximum number of suggestions to provide
+        /// </summary>
+        private const int SuggestionCount = 3;
+
+        /// <summary>
+        /// Maximum distance to consider
+        /// </summary>
+        private const int MaxEditDistanceForSimilarity = 3;
+
+        /// <summary>
+        /// Get suggestions for functions similar to the given identifier
+        /// </summary>
+        /// <param name="id">Seed identifier</param>
+        /// <param name="context">Current SMT context</param>
+        /// <param name="arity">Arity of function to suggest</param>
+        /// <returns>Enumeration of suggested function identifiers</returns>
+        public IEnumerable<SmtIdentifier> GetFunctionSuggestions(SmtIdentifier id, SmtContext context, int arity)
+        {
+            var fns = context.Functions
+                .Where(fn => arity == -1 || fn.RankTemplates.Any(rt => rt.Arity == arity))
+                .Select(fn => new { fn.Name, Distance = ComputeEditDistance(id.Symbol, fn.Name.Symbol) })
+                .Where(p => p.Distance <= MaxEditDistanceForSimilarity)
+                .OrderBy(p => p.Distance)
+                .Take(SuggestionCount)
+                .Select(p => p.Name)
+                .ToList();
+
+            if (fns.Count == 0 && arity != -1)
+            {
+                return GetFunctionSuggestions(id, context, -1);
+            }
+            else
+            {
+                return fns;
+            }
+        }
+
+        /// <summary>
+        /// Get suggestions for variables or constants similar to the given identifier
+        /// </summary>
+        /// <param name="id">Seed identifier</param>
+        /// <param name="context">Current SMT context</param>
+        /// <param name="scope">Current SMT scope</param>
+        /// <returns>Enumeration of suggested variable or constant identifiers</returns>
+        public IEnumerable<SmtIdentifier> GetVariableSuggestions(SmtIdentifier id, SmtContext context, SmtScope scope)
+        {
+            // Check locals first
+            var locals = scope.Bindings
+                    .Select(vb => (Id: vb.Id, Distance: ComputeEditDistance(id.Symbol, vb.Id.Symbol)))
+                    .Where(p => p.Distance <= MaxEditDistanceForSimilarity);
+
+            var globals = context.Functions
+                .Where(fn => fn.RankTemplates.Any(rt => rt.Arity == 0))
+                .Select(f => (Id: f.Name, Distance: ComputeEditDistance(id.Symbol, f.Name.Symbol)))
+                .Where(p => p.Distance <= MaxEditDistanceForSimilarity);
+
+            return locals.Concat(globals)
+                .OrderBy(p => p.Distance)
+                .Take(SuggestionCount)
+                .Select(p => p.Id);
+        }
+
+        /// <summary>
+        /// Computes the edit distance between two strings.
+        /// Based on the Wagner-Fischer algorithm: https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm
+        ///    and extended to the Damerau–Levenshtein distance
+        /// </summary>
+        /// <param name="a">First string</param>
+        /// <param name="b">Second string</param>
+        /// <returns>Edit distance between strings</returns>
+        private static int ComputeEditDistance(string a, string b)
+        {
+            var distances = new int[a.Length + 1, b.Length + 1];
+            for (int i = 0; i < a.Length; ++i)
+            {
+                distances[i + 1, 0] = i + 1;
+            }
+            for (int j = 0; j < b.Length; ++j)
+            {
+                distances[0, j + 1] = j + 1;
+            }
+            for (int j = 0; j < b.Length; ++j)
+            {
+                for (int i = 0; i < a.Length; ++i)
+                {
+                    int substCost;
+                    if (a[i] == b[j])
+                    {
+                        substCost = 0;
+                    }
+                    else
+                    {
+                        substCost = 1;
+                    }
+
+                    distances[i + 1, j + 1] = Math.Min(distances[i, j + 1] + 1,
+                                                   Math.Min(distances[i + 1, j] + 1,
+                                                        distances[i, j] + substCost));
+                    if (i > 0 && j > 0 && a[i] == b[j - 1] && a[i - 1] == b[j])
+                    {
+                        distances[i + 1, j + 1] = Math.Min(distances[i + 1, j + 1],
+                                                           distances[i - 1, j - 1] + 1);
+                    }
+                }
+            }
+            return distances[a.Length, b.Length];
+        }
+    }
+}

--- a/ParserLibrary/Reader/ISuggestionGenerator.cs
+++ b/ParserLibrary/Reader/ISuggestionGenerator.cs
@@ -1,0 +1,34 @@
+﻿using Semgus.Model.Smt;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Semgus.Parser.Reader
+{
+    /// <summary>
+    /// Generates suggestions for identifiers based on context
+    /// </summary>
+    internal interface ISuggestionGenerator
+    {
+        /// <summary>
+        /// Get suggestions for functions similar to the given identifier
+        /// </summary>
+        /// <param name="id">Seed identifier</param>
+        /// <param name="context">Current SMT context</param>
+        /// <param name="arity">Arity of function to suggest</param>
+        /// <returns>Enumeration of suggested function identifiers</returns>
+        IEnumerable<SmtIdentifier> GetFunctionSuggestions(SmtIdentifier id, SmtContext context, int arity);
+        
+        /// <summary>
+        /// Get suggestions for variables or constants similar to the given identifier
+        /// </summary>
+        /// <param name="id">Seed identifier</param>
+        /// <param name="context">Current SMT context</param>
+        /// <param name="scope">Current SMT scope</param>
+        /// <returns>Enumeration of suggested variable or constant identifiers</returns>
+        IEnumerable<SmtIdentifier> GetVariableSuggestions(SmtIdentifier id, SmtContext context, SmtScope scope);
+    }
+}

--- a/ParserLibrary/Reader/ReaderLogger.cs
+++ b/ParserLibrary/Reader/ReaderLogger.cs
@@ -123,7 +123,8 @@ namespace Semgus.Parser.Reader
             {
                 _writer.WriteLine("Error reported here:");
                 _writer.WriteLine(ctxLine);
-                _writer.WriteLine(new string('-', rls.Position.Column - 1) + "^");
+                _writer.WriteLine(new string('~', rls.Position.Column - 1) + "^");
+                _writer.WriteLine();
             }
         }
 

--- a/ParserLibrary/Reader/SemgusContextProvider.cs
+++ b/ParserLibrary/Reader/SemgusContextProvider.cs
@@ -1,20 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Semgus.Model;
+﻿using Semgus.Model;
 
 namespace Semgus.Parser.Reader
 {
+    /// <summary>
+    /// Holds a reference to the current SemGuS context
+    /// </summary>
     public interface ISemgusContextProvider
     {
+        /// <summary>
+        /// The current SemGuS context
+        /// </summary>
         public SemgusContext Context { get; set; }
     }
 
+    /// <summary>
+    /// Holds a reference to the current SemGuS context
+    /// </summary>
     internal class SemgusContextProvider : ISemgusContextProvider
     {
+        /// <summary>
+        /// The current SemGuS context
+        /// </summary>
         public SemgusContext Context { get; set; }
     }
 }

--- a/ParserLibrary/Reader/SmtContextProvider.cs
+++ b/ParserLibrary/Reader/SmtContextProvider.cs
@@ -1,20 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Semgus.Model.Smt;
+﻿using Semgus.Model.Smt;
 
 namespace Semgus.Parser.Reader
 {
+    /// <summary>
+    /// Holds a reference to the current SMT context
+    /// </summary>
     public interface ISmtContextProvider
     {
+        /// <summary>
+        /// The current SMT context
+        /// </summary>
         public SmtContext Context { get; set; }
     }
 
+    /// <summary>
+    /// Holds a reference to the current SMT context
+    /// </summary>
     internal class SmtContextProvider : ISmtContextProvider
     {
+        /// <summary>
+        /// The current SMT context
+        /// </summary>
         public SmtContext Context { get; set; }
     }
 }

--- a/ParserLibrary/Reader/TermErrorSearcher.cs
+++ b/ParserLibrary/Reader/TermErrorSearcher.cs
@@ -1,0 +1,63 @@
+﻿using Semgus.Model.Smt.Terms;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Semgus.Parser.Reader
+{
+    /// <summary>
+    /// Checks a term hierarchy for error terms
+    /// </summary>
+    internal class TermErrorSearcher : ISmtTermVisitor<bool>
+    {
+        public bool VisitExistsBinder(SmtExistsBinder existsBinder)
+            => existsBinder.Sort is ErrorSort
+            || existsBinder.Child is ErrorTerm
+            || existsBinder.Child.Accept(this);
+
+        public bool VisitForallBinder(SmtForallBinder forallBinder)
+            => forallBinder.Sort is ErrorSort
+            || forallBinder.Child is ErrorTerm
+            || forallBinder.Child.Accept(this);
+
+        public bool VisitFunctionApplication(SmtFunctionApplication functionApplication)
+            => functionApplication.Sort is ErrorSort
+            || functionApplication.Arguments.Any(arg => arg is ErrorTerm || arg.Accept(this));
+
+        public bool VisitNumeralLiteral(SmtNumeralLiteral numeralLiteral)
+            => false;
+
+        public bool VisitDecimalLiteral(SmtDecimalLiteral decimalLiteral)
+            => false;
+
+        public bool VisitStringLiteral(SmtStringLiteral stringLiteral)
+            => false;
+
+        public bool VisitVariable(SmtVariable variable)
+            => variable.Sort is ErrorSort;
+
+        public bool VisitMatchGrouper(SmtMatchGrouper matchGrouper)
+            => matchGrouper.Sort is ErrorSort
+            || matchGrouper.Term is ErrorTerm
+            || matchGrouper.Term.Accept(this)
+            || matchGrouper.Binders.Any(mb => mb.Accept(this));
+
+        public bool VisitMatchBinder(SmtMatchBinder matchBinder)
+            => matchBinder.Sort is ErrorSort
+            || matchBinder.Child is ErrorTerm
+            || matchBinder.Child.Accept(this);
+
+        public bool VisitLambdaBinder(SmtLambdaBinder lambdaBinder)
+            => lambdaBinder.Sort is ErrorSort
+            || lambdaBinder.Child is ErrorTerm
+            || lambdaBinder.Child.Accept(this);
+
+        public bool VisitLetBinder(SmtLetBinder letBinder)
+            => letBinder.Sort is ErrorSort
+            || letBinder.Child is ErrorTerm
+            || letBinder.Child.Accept(this);
+    }
+}

--- a/ParserLibrary/SemgusParser.cs
+++ b/ParserLibrary/SemgusParser.cs
@@ -105,6 +105,7 @@ namespace Semgus.Parser
             ServiceCollection services = new ServiceCollection();
             services.AddSingleton<ISmtConverter, Reader.Converters.SmtConverter>();
             services.AddSingleton<DestructuringHelper>();
+            services.AddSingleton<ISuggestionGenerator, DidYouMean>();
             services.AddSingleton<ISourceMap, SourceMap>();
             services.AddScoped<ISmtContextProvider, SmtContextProvider>();
             services.AddScoped<ISmtScopeProvider, SmtScopeProvider>();
@@ -201,7 +202,7 @@ namespace Semgus.Parser
                             {
                                 // Details should be logged when thrown
                                 errorStream.WriteLine($"\nTerminated parsing `{commandName.Name}` command due to fatal error.");
-                                errorStream.WriteLine("--------------------\n");
+                                errorStream.WriteLine($"{new string('=', 80)}\n");
                                 errCount += 1;
                             }
                             catch (InvalidOperationException ioe)

--- a/S-Expressions/Reader/SexprReader.cs
+++ b/S-Expressions/Reader/SexprReader.cs
@@ -253,7 +253,8 @@ namespace Semgus.Sexpr.Reader
             }
 
             // Save off the current position to use when processing constituents
-            SexprPosition position = CurrentPosition;
+            // Note this is plus one column because we only peeked at the first character
+            SexprPosition position = CurrentPosition.NextColumn();
 
             // Otherwise, read constituents until the next character of another syntax type
             string constituents = ConsumeConstituents();

--- a/Semgus-Lib/Model/Smt/SmtScope.cs
+++ b/Semgus-Lib/Model/Smt/SmtScope.cs
@@ -31,7 +31,16 @@ namespace Semgus.Model.Smt
             }
         }
 
+        /// <summary>
+        /// All variable bindings local to this scope
+        /// </summary>
         public IReadOnlyCollection<SmtVariableBinding> LocalBindings { get => _variableBindings.Values; }
+
+        /// <summary>
+        /// All variable bindings in this scope and parent scopes
+        /// </summary>
+        public IEnumerable<SmtVariableBinding> Bindings
+            => LocalBindings.Concat(Parent?.Bindings ?? Enumerable.Empty<SmtVariableBinding>());
 
         public SmtVariableBinding AddVariableBinding(SmtIdentifier id, SmtSort sort, SmtVariableBindingType bindingType)
         {

--- a/Semgus-Lib/Model/Smt/Terms/ISmtTermVisitor.cs
+++ b/Semgus-Lib/Model/Smt/Terms/ISmtTermVisitor.cs
@@ -15,5 +15,9 @@ namespace Semgus.Model.Smt.Terms
         public TOutput VisitDecimalLiteral(SmtDecimalLiteral decimalLiteral);
         public TOutput VisitExistsBinder(SmtExistsBinder existsBinder);
         public TOutput VisitForallBinder(SmtForallBinder forallBinder);
+        public TOutput VisitMatchGrouper(SmtMatchGrouper matchGrouper);
+        public TOutput VisitMatchBinder(SmtMatchBinder matchBinder);
+        public TOutput VisitLambdaBinder(SmtLambdaBinder lambdaBinder);
+        public TOutput VisitLetBinder(SmtLetBinder letBinder);
     }
 }

--- a/Semgus-Lib/Model/Smt/Terms/SmtLambdaBinder.cs
+++ b/Semgus-Lib/Model/Smt/Terms/SmtLambdaBinder.cs
@@ -17,7 +17,7 @@ namespace Semgus.Model.Smt.Terms
 
         public override TOutput Accept<TOutput>(ISmtTermVisitor<TOutput> visitor)
         {
-            throw new NotImplementedException();
+            return visitor.VisitLambdaBinder(this);
         }
     }
 }

--- a/Semgus-Lib/Model/Smt/Terms/SmtLetBinder.cs
+++ b/Semgus-Lib/Model/Smt/Terms/SmtLetBinder.cs
@@ -12,7 +12,7 @@ namespace Semgus.Model.Smt.Terms
 
         public override TOutput Accept<TOutput>(ISmtTermVisitor<TOutput> visitor)
         {
-            throw new NotImplementedException();
+            return visitor.VisitLetBinder(this);
         }
     }
 }

--- a/Semgus-Lib/Model/Smt/Terms/SmtMatchBinder.cs
+++ b/Semgus-Lib/Model/Smt/Terms/SmtMatchBinder.cs
@@ -20,7 +20,7 @@ namespace Semgus.Model.Smt.Terms
 
         public override TOutput Accept<TOutput>(ISmtTermVisitor<TOutput> visitor)
         {
-            throw new NotImplementedException();
+            return visitor.VisitMatchBinder(this);
         }
     }
 
@@ -41,7 +41,7 @@ namespace Semgus.Model.Smt.Terms
 
         public override TOutput Accept<TOutput>(ISmtTermVisitor<TOutput> visitor)
         {
-            throw new NotImplementedException();
+            return visitor.VisitMatchGrouper(this);
         }
     }
 }

--- a/SemgusParser/Json/Converters/SmtTermConverter.cs
+++ b/SemgusParser/Json/Converters/SmtTermConverter.cs
@@ -111,6 +111,26 @@ namespace Semgus.Parser.Json.Converters
                                           forallBinder.Child));
                 return this;
             }
+
+            public object VisitMatchGrouper(SmtMatchGrouper matchGrouper)
+            {
+                throw new NotImplementedException();
+            }
+
+            public object VisitMatchBinder(SmtMatchBinder matchBinder)
+            {
+                throw new NotImplementedException();
+            }
+
+            public object VisitLambdaBinder(SmtLambdaBinder lambdaBinder)
+            {
+                throw new NotImplementedException();
+            }
+
+            public object VisitLetBinder(SmtLetBinder letBinder)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request introduces the following changes:
* The did-you-mean (DYM) facility now considers functions and variables/constants separately
* The DYM facility now handles locally-bound variables
* Improvements to the DYM edit distance algorithm
* Now, only the top three candidates are returned
* The DYM facility checks for function arity and, if no matches, falls back to all in-scope functions
* Error message deduplication, so only one error will be printed at the source instead of also at intermediate nodes
* Fixes a calculation error with identifier positions

Closes #59 and #58. 