### PR TITLE
Remove selectors from `declare-term-types` command

### DIFF
--- a/ParserLibrary/Commands/DeclareTermTypeCommand.cs
+++ b/ParserLibrary/Commands/DeclareTermTypeCommand.cs
@@ -67,12 +67,12 @@ namespace Semgus.Parser.Commands
                     List<SmtSort> children = new();
                     foreach (var child in constructor.Children)
                     {
-                        if (_context.Context.TryGetSortDeclaration(child.Sort, out SmtSort? sort)) {
+                        if (_context.Context.TryGetSortDeclaration(child, out SmtSort? sort)) {
                             children.Add(sort);
                         }
                         else
                         {
-                            throw _logger.LogParseErrorAndThrow("Sort not declared: " + child.Sort, _sourceMap[child.Sort]);
+                            throw _logger.LogParseErrorAndThrow("Sort not declared: " + child, _sourceMap[child]);
                         }
                     }
                     termTypes[ix].AddConstructor(new(constructor.Constructor, children.ToArray()));
@@ -83,6 +83,6 @@ namespace Semgus.Parser.Commands
         }
 
         public record SortDecl(SmtSortIdentifier Identifier, int Arity) { }
-        public record ConstructorDecl(SmtIdentifier Constructor, [Rest] IList<(SmtIdentifier Selector, SmtSortIdentifier Sort)> Children) { }
+        public record ConstructorDecl(SmtIdentifier Constructor, [Rest] IList<SmtSortIdentifier> Children) { }
     }
 }

--- a/SemgusParser/TestInput.cs
+++ b/SemgusParser/TestInput.cs
@@ -31,15 +31,15 @@ namespace Semgus.Parser
   ($y)
    ($0)
    ($1)
-   ($+ ($+_1 E) ($+_2 E))
-   ($ite($ite_1 B) ($ite_2 E) ($ite_3 E)))
+   ($+ E E)
+   ($ite B E E))
 
   (($t) ; B productions
    ($f)
-   ($! ($!_1 B))
-   ($and($and_1 B) ($and_2 B))
-   ($or($or_1 B) ($or_2 B))
-   ($< ($<_1 E) ($<_2 E)))))
+   ($! B)
+   ($and B B)
+   ($or B B)
+   ($< E E))))
 
 ;;;
 ;;; Semantics


### PR DESCRIPTION
Closes #78.

Fix was trivial, since the parser was just ignoring the selectors anyway.

Note: in existing problem files, you'll get an error that, e.g., the sort `($+_1 E)` isn't defined. That is, it's treating it as a parametric sort instead of a selector and sort together.