### PR TITLE
Parametric Sorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This project is under active development and does not yet support all SMT-LIB2 f
 * Strings (with partial support for regular expressions)
 * Bit vectors (partial support; only theory functions supported for now)
 * Datatypes (non-parametric only)
+* Arrays (partial support)
 
 Other features:
 * Converting SyGuS problems to CHCs on the fly (beta)
@@ -42,14 +43,12 @@ New additions:
 * Arbitrary `match` expressions
 
 Unsupported SMT-LIB2 features include:
-* Parametric sorts
 * Theory functions annotated with `:left-assoc`, `:right-assoc`, `:chainable`, and `:pairwise`. Certain Core functions are implemented, so post an issue if others are needed.
 * Some terms, including `let`
 * Uninterpreted sorts (`declare-sort`) and sort aliases (`define-sort`)
 
 The roadmap for next-up features includes:
 * Arbitrary `let` terms
-* Parameteric sorts
 
 If there is an unsupported feature that you would like added, drop us a line by submitting an issue (or commenting on an existing one).
 This will help us prioritize what to put on our roadmap.

--- a/Semgus-Lib/Model/Smt/SmtCommonIdentifiers.cs
+++ b/Semgus-Lib/Model/Smt/SmtCommonIdentifiers.cs
@@ -16,6 +16,7 @@ namespace Semgus.Model.Smt
         public static SmtIdentifier StringsTheoryId { get; } = new("Strings");
         public static SmtIdentifier BitVectorsTheoryId { get; } = new("BitVectors");
         public static SmtIdentifier BitVectorsExtensionId { get; } = new("BitVectors", "extension");
+        public static SmtIdentifier ArraysExTheoryId { get; } = new("ArraysEx");
 
         public static SmtSortIdentifier BoolSortId { get; } = new("Bool");
         public static SmtSortIdentifier IntSortId { get; } = new("Int");
@@ -32,6 +33,7 @@ namespace Semgus.Model.Smt
                                              new SmtIdentifier.Index(size)));
             }
         }
+        public static SmtIdentifier ArraySortPrimaryId { get; } = new("Array");
 
         public static SmtIdentifier AndFunctionId { get; } = new("and");
         public static SmtIdentifier OrFunctionId { get; } = new("or");

--- a/Semgus-Lib/Model/Smt/SmtContext.cs
+++ b/Semgus-Lib/Model/Smt/SmtContext.cs
@@ -64,7 +64,8 @@ namespace Semgus.Model.Smt
                 SmtCoreTheory.Instance,
                 SmtIntsTheory.Instance,
                 SmtStringsTheory.Instance,
-                SmtBitVectorsTheory.Instance
+                SmtBitVectorsTheory.Instance,
+                SmtArraysExTheory.Instance
             };
 
             _extensions = new HashSet<ISmtExtension>()
@@ -249,7 +250,7 @@ namespace Semgus.Model.Smt
                 return false;
             }
 
-            if (candidate.Arity == 0)
+            if (candidate.Arity == 0 || !candidate.IsParametric)
             {
                 resolved = candidate;
                 error = default;
@@ -266,13 +267,16 @@ namespace Semgus.Model.Smt
                 else
                 {
                     resolved = default;
+                    error = $"Unable to resolve sort parameter {child.Name} in parametric sort {id.Name}: {error}";
                     return false;
                 }
             }
 
-            resolved = default;
-            error = "Not finished being implemented";
-            return false;
+            candidate.UpdateForResolvedParameters(resolvedSubsorts);
+
+            resolved = candidate;
+            error = "";
+            return true;
         }
 
         public void Push()

--- a/Semgus-Lib/Model/Smt/SmtSort.cs
+++ b/Semgus-Lib/Model/Smt/SmtSort.cs
@@ -27,7 +27,7 @@ namespace Semgus.Model.Smt
         public SmtSortIdentifier Name { get; }
 
         /// <summary>
-        /// Does this sort have parameters?
+        /// Does this sort have parameters that need to be resolved?
         /// </summary>
         public bool IsParametric { get; protected set; } = false;
 
@@ -42,6 +42,12 @@ namespace Semgus.Model.Smt
         public int Arity { get; protected set; } = 0;
 
         /// <summary>
+        /// Updates this sort for resolved parameters
+        /// </summary>
+        /// <param name="resolved">Resolved parameters. Should have same length as arity</param>
+        public virtual void UpdateForResolvedParameters(IList<SmtSort> resolved) { }
+
+        /// <summary>
         /// An arbitrary generic sort
         /// </summary>
         internal class GenericSort : SmtSort
@@ -52,6 +58,28 @@ namespace Semgus.Model.Smt
             /// <param name="name">The sort name</param>
             public GenericSort(SmtSortIdentifier name) : base(name)
             { }
+        }
+
+        /// <summary>
+        /// A sort parameter that needs to be resolved to a real sort
+        /// </summary>
+        internal class UnresolvedParameterSort : SmtSort
+        {
+            /// <summary>
+            /// Identifier that needs to be resolved
+            /// </summary>
+            public SmtSortIdentifier Identifier { get; }
+
+            /// <summary>
+            /// Creates a new unresolved sort. This is a placeholder for sort parameters to be resolved.
+            /// </summary>
+            /// <param name="identifier">Sort identifier to resolve</param>
+            public UnresolvedParameterSort(SmtSortIdentifier identifier) : base(identifier)
+            {
+                Identifier = identifier;
+                IsSortParameter = true;
+                Arity = identifier.Arity;
+            }
         }
 
         /// <summary>

--- a/Semgus-Lib/Model/Smt/Theories/SmtArraysExTheory.cs
+++ b/Semgus-Lib/Model/Smt/Theories/SmtArraysExTheory.cs
@@ -1,0 +1,156 @@
+﻿using Semgus.Model.Smt.Terms;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using static Semgus.Model.Smt.SmtCommonIdentifiers;
+
+namespace Semgus.Model.Smt.Theories
+{
+    /// <summary>
+    /// The theory of arrays with extensions
+    /// </summary>
+    internal class SmtArraysExTheory : ISmtTheory
+    {
+        /// <summary>
+        /// A singleton theory instance
+        /// </summary>
+        public static SmtArraysExTheory Instance { get; } = new();
+
+        /// <summary>
+        /// Underlying array sort
+        /// </summary>
+        internal sealed class ArraySort : SmtSort
+        {
+            /// <summary>
+            /// Cache of instantiated sorts. We need this since sorts are compared by reference
+            /// </summary>
+            private static readonly IDictionary<(SmtSortIdentifier, SmtSortIdentifier), ArraySort> _sortCache
+                = new Dictionary<(SmtSortIdentifier, SmtSortIdentifier), ArraySort>();
+
+            /// <summary>
+            /// The sort used for indexing the array
+            /// </summary>
+            public SmtSort IndexSort { get; private set; }
+
+            /// <summary>
+            /// The sort used for the array element values
+            /// </summary>
+            public SmtSort ValueSort { get; private set; }
+
+            /// <summary>
+            /// Constructs a new array sort with the given parameters
+            /// </summary>
+            /// <param name="size">Size of bit vectors in this sort</param>
+            private ArraySort(SmtSortIdentifier indexSort, SmtSortIdentifier valueSort) :
+                base(new(new SmtIdentifier(ArraySortPrimaryId.Symbol), indexSort, valueSort))
+            {
+                IndexSort = new UnresolvedParameterSort(indexSort);
+                ValueSort = new UnresolvedParameterSort(valueSort);
+                IsParametric = true;
+                Arity = 2;
+            }
+
+            /// <summary>
+            /// Gets the array sort for the given index and value sorts
+            /// </summary>
+            /// <param name="index">The index sort to use</param>
+            /// <param name="value">The value sort to use</param>
+            /// <returns>The array sort for the given index and value sorts</returns>
+            public static ArraySort GetSort(SmtSortIdentifier index, SmtSortIdentifier value)
+            {
+                if (_sortCache.TryGetValue((index, value), out ArraySort? sort))
+                {
+                    return sort;
+                }
+                else
+                {
+                    sort = new ArraySort(index, value);
+                    _sortCache.Add((index, value), sort);
+                    return sort;
+                }
+            }
+
+            /// <summary>
+            /// Updates this sort with the resolved parameteric sorts
+            /// </summary>
+            /// <param name="resolved">Resolved parameters. Must have arity 2</param>
+            public override void UpdateForResolvedParameters(IList<SmtSort> resolved)
+            {
+                if (resolved.Count != 2)
+                {
+                    throw new InvalidOperationException("Got list of resolved sorts not of length 2!");
+                }
+
+                IndexSort = resolved[0];
+                ValueSort = resolved[1];
+            }
+        }
+
+        /// <summary>
+        /// This theory's name
+        /// </summary>
+        public SmtIdentifier Name { get; } = ArraysExTheoryId;
+
+        #region Deprecated
+        public IReadOnlyDictionary<SmtIdentifier, IApplicable> Functions { get; }
+        #endregion
+
+        /// <summary>
+        /// The primary (i.e., non-indexed) sort symbols (e.g., "Array")
+        /// </summary>
+        public IReadOnlySet<SmtIdentifier> PrimarySortSymbols { get; }
+
+        /// <summary>
+        /// The primary (i.e., non-indexed) function symbols
+        /// </summary>
+        public IReadOnlySet<SmtIdentifier> PrimaryFunctionSymbols { get; }
+
+        /// <summary>
+        /// Constructs an instance of the theory of arrays
+        /// </summary>
+        /// <param name="core">Reference to the core theory</param>
+        private SmtArraysExTheory()
+        {
+            SmtSourceBuilder sb = new(this);
+            sb.AddOnTheFlyFn("select");
+            sb.AddOnTheFlyFn("store");
+
+            Functions = sb.Functions;
+            PrimaryFunctionSymbols = sb.PrimaryFunctionSymbols;
+            PrimarySortSymbols = new HashSet<SmtIdentifier>() { ArraySortPrimaryId };
+        }
+
+        /// <summary>
+        /// Looks up a sort symbol in this theory
+        /// </summary>
+        /// <param name="sortId">The sort ID</param>
+        /// <param name="resolvedSort">The resolved sort</param>
+        /// <returns>True if successfully gotten</returns>
+        public bool TryGetSort(SmtSortIdentifier sortId, [NotNullWhen(true)] out SmtSort? resolvedSort)
+        {
+            if (sortId.Arity == 2 && sortId.Name == ArraySortPrimaryId)
+            {
+                resolvedSort = ArraySort.GetSort(sortId.Parameters[0], sortId.Parameters[1]);
+                return true;
+            }
+            resolvedSort = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Looks up a function in this theory
+        /// </summary>
+        /// <param name="functionId">The function ID to look up</param>
+        /// <param name="resolvedFunction">The resolved function</param>
+        /// <returns>True if successfully gotten</returns>
+        public bool TryGetFunction(SmtIdentifier functionId, [NotNullWhen(true)] out IApplicable? resolvedFunction)
+        {
+            return Functions.TryGetValue(functionId, out resolvedFunction);
+        }
+    }
+}

--- a/SemgusParser/Json/Converters/SmtIdentifierConverter.cs
+++ b/SemgusParser/Json/Converters/SmtIdentifierConverter.cs
@@ -41,7 +41,8 @@ namespace Semgus.Parser.Json.Converters
                     }
                     else
                     {
-                        writer.WriteValue(index.StringValue);
+                        throw new InvalidOperationException("Indexes cannot be strings; they must be integers.");
+                        // writer.WriteValue(index.StringValue);
                     }
                 }
                 writer.WriteEndArray();

--- a/SemgusParser/Json/Converters/SmtSortIdentifierConverter.cs
+++ b/SemgusParser/Json/Converters/SmtSortIdentifierConverter.cs
@@ -29,14 +29,20 @@ namespace Semgus.Parser.Json.Converters
                 throw new InvalidOperationException("Attepted to serialize the wrong thing.");
             }
 
-            if (id.Parameters.Length > 0)
+            // if (id.Parameters.Length > 0)
             {
-                throw new InvalidOperationException("Parameterized sorts not yet supported by the JSON serializer.");
-            }
-            else
-            {
+                writer.WriteStartArray();
                 serializer.Serialize(writer, id.Name);
-            }            
+                foreach (var sort in id.Parameters)
+                {
+                    serializer.Serialize(writer, sort);
+                }
+                writer.WriteEndArray();
+            }
+            // else
+            // {
+            //     serializer.Serialize(writer, id.Name);
+            // }            
         }
     }
 }


### PR DESCRIPTION
- Partial support for ArraysEX theory added
- JSON output for parametric sorts defined:
    - Sorts are arrays of the form [ <identifier> ] or [ <identifier>, <sort>+]
    - e.g., [Int], [[Bitvec, 32]], [Array, [Int], [Int]]
    - It's not the most aesthetic, but it's easy to parse unambiguously.